### PR TITLE
Extend Adyen plugin to support SepaDirectDebit and ELV

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentPluginApi.java
@@ -19,6 +19,7 @@ package org.killbill.billing.plugin.adyen.api;
 import java.math.BigDecimal;
 import java.net.URISyntaxException;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
@@ -53,6 +54,8 @@ import org.killbill.billing.plugin.adyen.client.model.PurchaseResult;
 import org.killbill.billing.plugin.adyen.client.model.SplitSettlementData;
 import org.killbill.billing.plugin.adyen.client.model.UserData;
 import org.killbill.billing.plugin.adyen.client.model.paymentinfo.CreditCard;
+import org.killbill.billing.plugin.adyen.client.model.paymentinfo.Elv;
+import org.killbill.billing.plugin.adyen.client.model.paymentinfo.SepaDirectDebit;
 import org.killbill.billing.plugin.adyen.client.model.paymentinfo.WebPaymentFrontend;
 import org.killbill.billing.plugin.adyen.client.notification.AdyenNotificationHandler;
 import org.killbill.billing.plugin.adyen.client.notification.AdyenNotificationService;
@@ -120,6 +123,11 @@ public class AdyenPaymentPluginApi extends PluginPaymentPluginApi<AdyenResponses
     public static final String PROPERTY_DCC_SIGNATURE = "dccSignature";
     public static final String PROPERTY_ISSUER_URL = "issuerUrl";
     public static final String PROPERTY_TERM_URL = "TermUrl";
+
+    public static final String PROPERTY_DD_HOLDER_NAME = "ddHolderName";
+    public static final String PROPERTY_DD_ACCOUNT_NUMBER = "ddNumber";
+    public static final String PROPERTY_DD_BANK_IDENTIFIER_CODE = "ddBic";
+    public static final String PROPERTY_DD_BANKLEITZAHL = "ddBlz";
 
     private final AdyenConfigurationHandler adyenConfigurationHandler;
     private final AdyenHostedPaymentPageConfigurationHandler adyenHppConfigurationHandler;
@@ -435,47 +443,96 @@ public class AdyenPaymentPluginApi extends PluginPaymentPluginApi<AdyenResponses
     }
 
     // For API
-    // TODO Generify
     private PaymentInfo buildPaymentInfo(final Account account, final UUID kbPaymentMethodId, final Currency currency, final Iterable<PluginProperty> properties, final CallContext context) {
         final AdyenPaymentMethodsRecord paymentMethodsRecord = getAdyenPaymentMethodsRecord(kbPaymentMethodId, context);
         final PaymentProvider paymentProvider = buildPaymentProvider(account, paymentMethodsRecord, currency, properties, context);
 
-        // By convention, support the same keys as the Ruby plugins (https://github.com/killbill/killbill-plugin-framework-ruby/blob/master/lib/killbill/helpers/active_merchant/payment_plugin.rb)
-        final String pluginPropertyCcNumber = PluginProperties.findPluginPropertyValue(PROPERTY_CC_NUMBER, properties);
-        final String paymentMethodCcNumber = paymentMethodsRecord == null ? null : paymentMethodsRecord.getCcNumber();
-        final String ccNumber = pluginPropertyCcNumber == null ? paymentMethodCcNumber : pluginPropertyCcNumber;
-        if (ccNumber != null) {
-            final String paymentMethodExpirationMonth = paymentMethodsRecord == null ? null : paymentMethodsRecord.getCcExpMonth();
-            final String ccExpirationMonth = PluginProperties.getValue(PROPERTY_CC_EXPIRATION_MONTH, paymentMethodExpirationMonth, properties);
+        final String paymentMethodsRecordCcType = paymentMethodsRecord != null ? paymentMethodsRecord.getCcType() : null;
+        final String ccType = PluginProperties.getValue(PROPERTY_CC_TYPE, paymentMethodsRecordCcType, properties);
 
-            final String paymentMethodExpirationYear = paymentMethodsRecord == null ? null : paymentMethodsRecord.getCcExpYear();
-            final String ccExpirationYear = PluginProperties.getValue(PROPERTY_CC_EXPIRATION_YEAR, paymentMethodExpirationYear, properties);
-
-            final String paymentMethodVerificationValue = paymentMethodsRecord == null ? null : paymentMethodsRecord.getCcVerificationValue();
-            final String ccVerificationValue = PluginProperties.getValue(PROPERTY_CC_VERIFICATION_VALUE, paymentMethodVerificationValue, properties);
-
-            final String paymentMethodCcFirstName = paymentMethodsRecord == null ? null : paymentMethodsRecord.getCcFirstName();
-            final String ccFirstName = PluginProperties.getValue(PROPERTY_CC_FIRST_NAME, paymentMethodCcFirstName, properties);
-
-            final String paymentMethodCcLastName = paymentMethodsRecord == null ? null : paymentMethodsRecord.getCcLastName();
-            final String ccLastName = PluginProperties.getValue(PROPERTY_CC_LAST_NAME, paymentMethodCcLastName, properties);
-
-            final CreditCard paymentInfo = new CreditCard(paymentProvider);
-            paymentInfo.setCcHolderName(String.format("%s%s%s", ccFirstName, ccFirstName == null ? "" : " ", ccLastName));
-            paymentInfo.setCcNumber(ccNumber);
-            if (ccExpirationMonth != null) {
-                paymentInfo.setValidUntilMonth(Integer.valueOf(ccExpirationMonth));
-            }
-            if (ccExpirationYear != null) {
-                paymentInfo.setValidUntilYear(Integer.valueOf(ccExpirationYear));
-            }
-            if (ccVerificationValue != null) {
-                paymentInfo.setCcSecCode(ccVerificationValue);
-            }
-
-            return paymentInfo;
+        if ("creditcard".equals(ccType)) {
+            return buildCreditCard(paymentMethodsRecord, paymentProvider, properties);
+        } else if ("sepaDirectDebit".equals(ccType)) {
+            return buildSepaDirectDebit(paymentMethodsRecord, paymentProvider, properties);
+        } else if ("elv".equals(ccType)) {
+            return buildElv(paymentMethodsRecord, paymentProvider, properties);
         }
+
         return null;
+    }
+
+    private CreditCard buildCreditCard(final AdyenPaymentMethodsRecord paymentMethodsRecord, final PaymentProvider paymentProvider, final Iterable<PluginProperty> properties) {
+        final AdyenPaymentMethodsRecord nonNullPaymentMethodsRecord = paymentMethodsRecord == null ? new AdyenPaymentMethodsRecord() : paymentMethodsRecord;
+        final CreditCard creditCard = new CreditCard(paymentProvider);
+
+        // By convention, support the same keys as the Ruby plugins (https://github.com/killbill/killbill-plugin-framework-ruby/blob/master/lib/killbill/helpers/active_merchant/payment_plugin.rb)
+        final String ccNumber = PluginProperties.getValue(PROPERTY_CC_NUMBER, nonNullPaymentMethodsRecord.getCcNumber(), properties);
+        creditCard.setCcNumber(ccNumber);
+
+        final String ccFirstName = PluginProperties.getValue(PROPERTY_CC_FIRST_NAME, nonNullPaymentMethodsRecord.getCcFirstName(), properties);
+        final String ccLastName = PluginProperties.getValue(PROPERTY_CC_LAST_NAME, nonNullPaymentMethodsRecord.getCcLastName(), properties);
+        creditCard.setCcHolderName(holderName(ccFirstName, ccLastName));
+
+        final String ccExpirationMonth = PluginProperties.getValue(PROPERTY_CC_EXPIRATION_MONTH, nonNullPaymentMethodsRecord.getCcExpMonth(), properties);
+        if (ccExpirationMonth != null) {
+            creditCard.setValidUntilMonth(Integer.valueOf(ccExpirationMonth));
+        }
+
+        final String ccExpirationYear = PluginProperties.getValue(PROPERTY_CC_EXPIRATION_YEAR, nonNullPaymentMethodsRecord.getCcExpYear(), properties);
+        if (ccExpirationYear != null) {
+            creditCard.setValidUntilYear(Integer.valueOf(ccExpirationYear));
+        }
+
+        final String ccVerificationValue = PluginProperties.getValue(PROPERTY_CC_VERIFICATION_VALUE, nonNullPaymentMethodsRecord.getCcVerificationValue(), properties);
+        if (ccVerificationValue != null) {
+            creditCard.setCcSecCode(ccVerificationValue);
+        }
+
+        return creditCard;
+    }
+
+    private SepaDirectDebit buildSepaDirectDebit(final AdyenPaymentMethodsRecord paymentMethodsRecord, final PaymentProvider paymentProvider, final Iterable<PluginProperty> properties) {
+        final AdyenPaymentMethodsRecord nonNullPaymentMethodsRecord = paymentMethodsRecord == null ? new AdyenPaymentMethodsRecord() : paymentMethodsRecord;
+        final List<PluginProperty> additionalProperties = buildPaymentMethodPlugin(paymentMethodsRecord).getProperties();
+        final SepaDirectDebit sepaDirectDebit = new SepaDirectDebit(paymentProvider);
+
+        // By convention, support the same keys as the Ruby plugins (https://github.com/killbill/killbill-plugin-framework-ruby/blob/master/lib/killbill/helpers/active_merchant/payment_plugin.rb)
+        final String ddAccountNumber = PluginProperties.getValue(PROPERTY_DD_ACCOUNT_NUMBER, nonNullPaymentMethodsRecord.getCcNumber(), properties);
+        sepaDirectDebit.setIban(ddAccountNumber);
+
+        final String paymentMethodHolderName = holderName(nonNullPaymentMethodsRecord.getCcFirstName(), nonNullPaymentMethodsRecord.getCcLastName());
+        final String ddHolderName = PluginProperties.getValue(PROPERTY_DD_HOLDER_NAME, paymentMethodHolderName, properties);
+        sepaDirectDebit.setSepaAccountHolder(ddHolderName);
+
+        final String paymentMethodBic = PluginProperties.findPluginPropertyValue(PROPERTY_DD_BANK_IDENTIFIER_CODE, additionalProperties);
+        final String ddBic = PluginProperties.getValue(PROPERTY_DD_BANK_IDENTIFIER_CODE, paymentMethodBic, properties);
+        sepaDirectDebit.setBic(ddBic);
+
+        return sepaDirectDebit;
+    }
+
+    private Elv buildElv(final AdyenPaymentMethodsRecord paymentMethodsRecord, final PaymentProvider paymentProvider, final Iterable<PluginProperty> properties) {
+        final AdyenPaymentMethodsRecord nonNullPaymentMethodsRecord = paymentMethodsRecord == null ? new AdyenPaymentMethodsRecord() : paymentMethodsRecord;
+        final List<PluginProperty> additionalProperties = buildPaymentMethodPlugin(paymentMethodsRecord).getProperties();
+        final Elv elv = new Elv(paymentProvider);
+
+        // By convention, support the same keys as the Ruby plugins (https://github.com/killbill/killbill-plugin-framework-ruby/blob/master/lib/killbill/helpers/active_merchant/payment_plugin.rb)
+        final String ddAccountNumber = PluginProperties.getValue(PROPERTY_DD_ACCOUNT_NUMBER, nonNullPaymentMethodsRecord.getCcNumber(), properties);
+        elv.setElvKontoNummer(ddAccountNumber);
+
+        final String paymentMethodHolderName = holderName(nonNullPaymentMethodsRecord.getCcFirstName(), nonNullPaymentMethodsRecord.getCcLastName());
+        final String ddHolderName = PluginProperties.getValue(PROPERTY_DD_HOLDER_NAME, paymentMethodHolderName, properties);
+        elv.setElvAccountHolder(ddHolderName);
+
+        final String paymentMethodBlz = PluginProperties.findPluginPropertyValue(PROPERTY_DD_BANKLEITZAHL, additionalProperties);
+        final String ddBlz = PluginProperties.getValue(PROPERTY_DD_BANKLEITZAHL, paymentMethodBlz, properties);
+        elv.setElvBlz(ddBlz);
+
+        return elv;
+    }
+
+    private static String holderName(final String firstName, final String lastName) {
+        return String.format("%s%s%s", firstName, firstName == null ? "" : " ", lastName);
     }
 
     // For HPP

--- a/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentPluginApi.java
@@ -27,10 +27,6 @@ import java.util.UUID;
 import javax.annotation.Nullable;
 import javax.xml.bind.JAXBException;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
-import com.google.common.base.Strings;
 import org.joda.time.DateTime;
 import org.killbill.billing.account.api.Account;
 import org.killbill.billing.catalog.api.Currency;
@@ -86,6 +82,10 @@ import org.killbill.killbill.osgi.libs.killbill.OSGIKillbillAPI;
 import org.killbill.killbill.osgi.libs.killbill.OSGIKillbillLogService;
 import org.osgi.service.log.LogService;
 
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -553,7 +553,7 @@ public class AdyenPaymentPluginApi extends PluginPaymentPluginApi<AdyenResponses
     }
 
     private static String holderName(final String firstName, final String lastName) {
-        return String.format("%s%s%s", firstName, firstName == null ? "" : " ", lastName);
+        return String.format("%s%s", firstName == null ? "" : firstName + " ", lastName);
     }
 
     // For HPP

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/model/paymentinfo/SepaDirectDebit.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/model/paymentinfo/SepaDirectDebit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Groupon, Inc
+ * Copyright 2015 Groupon, Inc
  *
  * Groupon licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/model/paymentinfo/SepaDirectDebit.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/model/paymentinfo/SepaDirectDebit.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2014 Groupon, Inc
+ *
+ * Groupon licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.plugin.adyen.client.model.paymentinfo;
+
+import org.killbill.billing.plugin.adyen.client.model.PaymentInfo;
+import org.killbill.billing.plugin.adyen.client.model.PaymentProvider;
+
+public class SepaDirectDebit extends PaymentInfo {
+
+    private String countryCode;
+    private String iban;
+    private String bic;
+    private String sepaAccountHolder;
+
+    public SepaDirectDebit(final PaymentProvider paymentProvider) {
+        super(paymentProvider);
+    }
+
+    public String getBic() {
+        return bic;
+    }
+
+    public void setBic(final String bic) {
+        this.bic = bic;
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    public void setCountryCode(final String countryCode) {
+        if (countryCode == null) {
+            this.countryCode = null;
+        } else {
+            this.countryCode = countryCode.replaceAll("\\s", "");
+        }
+    }
+
+    public String getIban() {
+        return iban;
+    }
+
+    public void setIban(final String iban) {
+        if (iban == null) {
+            this.iban = null;
+        } else {
+            this.iban = iban.replaceAll("\\s", "");
+        }
+    }
+
+    public String getSepaAccountHolder() {
+        return sepaAccountHolder;
+    }
+
+    public void setSepaAccountHolder(final String sepaAccountHolder) {
+        this.sepaAccountHolder = sepaAccountHolder;
+    }
+
+    @Override
+    public String toString() {
+        return "SepaDirectDebit{" +
+                "countryCode='" + countryCode + '\'' +
+                ", iban='" + iban + '\'' +
+                ", bic='" + bic + '\'' +
+                ", sepaAccountHolder='" + sepaAccountHolder + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final SepaDirectDebit sepaDirectDebit = (SepaDirectDebit) o;
+
+        if (sepaAccountHolder != null ? !sepaAccountHolder.equals(sepaDirectDebit.sepaAccountHolder) : sepaDirectDebit.sepaAccountHolder != null) {
+            return false;
+        }
+        if (bic != null ? !bic.equals(sepaDirectDebit.bic) : sepaDirectDebit.bic != null) {
+            return false;
+        }
+        if (countryCode != null ? !countryCode.equals(sepaDirectDebit.countryCode) : sepaDirectDebit.countryCode != null) {
+            return false;
+        }
+        if (iban != null ? !iban.equals(sepaDirectDebit.iban) : sepaDirectDebit.iban != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = countryCode != null ? countryCode.hashCode() : 0;
+        result = 31 * result + (iban != null ? iban.hashCode() : 0);
+        result = 31 * result + (bic != null ? bic.hashCode() : 0);
+        result = 31 * result + (sepaAccountHolder != null ? sepaAccountHolder.hashCode() : 0);
+        return result;
+    }
+}

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/converter/PaymentInfoConverter.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/converter/PaymentInfoConverter.java
@@ -25,17 +25,17 @@ public interface PaymentInfoConverter<T extends PaymentInfo> {
     /**
      * @return the payment type this converter is handling
      */
-    public PaymentType getPaymentType();
+    PaymentType getPaymentType();
 
     /**
      * Convert a PaymentInfo Object into an object understandable by the payment service provider
      */
-    public Object convertPaymentInfoToPSPTransferObject(String holderName, T paymentInfo);
+    Object convertPaymentInfoToPSPTransferObject(String holderName, T paymentInfo);
 
     /**
      * Return the matching BrowserInfo element for 3-D Secure authorisation (needed for maestro, optional for MasterCard/Visa)
      *
      * @return the BrowserInfo object or null if not needed
      */
-    public Object convertPaymentInfoFor3DSecureAuth(Long billedAmount, Card card);
+    Object convertPaymentInfoFor3DSecureAuth(Long billedAmount, Card card);
 }

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/converter/impl/AmexConverter.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/converter/impl/AmexConverter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Groupon, Inc
+ *
+ * Groupon licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.killbill.billing.plugin.adyen.client.payment.converter.impl;
 
 import org.killbill.billing.plugin.adyen.client.model.PaymentType;

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/converter/impl/AmexConverter.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/converter/impl/AmexConverter.java
@@ -1,0 +1,14 @@
+package org.killbill.billing.plugin.adyen.client.payment.converter.impl;
+
+import org.killbill.billing.plugin.adyen.client.model.PaymentType;
+
+import static org.killbill.billing.plugin.adyen.client.model.PaymentType.AMEX;
+
+public class AmexConverter extends CreditCardConverter {
+
+    @Override
+    public PaymentType getPaymentType() {
+        return AMEX;
+    }
+
+}

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/converter/impl/ElvConverter.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/converter/impl/ElvConverter.java
@@ -1,0 +1,49 @@
+package org.killbill.billing.plugin.adyen.client.payment.converter.impl;
+
+import org.killbill.adyen.payment.ELV;
+import org.killbill.adyen.payment.PaymentRequest;
+import org.killbill.billing.plugin.adyen.client.model.PaymentInfo;
+import org.killbill.billing.plugin.adyen.client.model.PaymentType;
+import org.killbill.billing.plugin.adyen.client.model.paymentinfo.Card;
+import org.killbill.billing.plugin.adyen.client.model.paymentinfo.Elv;
+import org.killbill.billing.plugin.adyen.client.payment.converter.PaymentInfoConverter;
+
+public class ElvConverter implements PaymentInfoConverter<Elv> {
+
+    @Override
+    public Object convertPaymentInfoToPSPTransferObject(final String holderName, final Elv paymentInfo) {
+        final ELV elv = new ELV();
+        elv.setBankAccountNumber(paymentInfo.getElvKontoNummer());
+        elv.setBankLocationId(paymentInfo.getElvBlz());
+        elv.setAccountHolderName(holderName(paymentInfo, holderName));
+        final PaymentRequest paymentRequest = new PaymentRequest();
+        paymentRequest.setElv(elv);
+        return paymentRequest;
+    }
+
+    /**
+     * There is no 3DSecure for ELV.
+     *
+     * @param billedAmount Billed amount.
+     * @param card {@link PaymentInfo} of type {@link Card}.
+     * @return Always {@literal null} for ELV.
+     */
+    @Override
+    public Object convertPaymentInfoFor3DSecureAuth(final Long billedAmount, final Card card) {
+        return null;
+    }
+
+    @Override
+    public PaymentType getPaymentType() {
+        return PaymentType.ELV;
+    }
+
+    private String holderName(final Elv elv, final String holderName) {
+        if (elv.getElvAccountHolder() != null && !elv.getElvAccountHolder().isEmpty()) {
+            return elv.getElvAccountHolder();
+        } else {
+            return holderName;
+        }
+    }
+
+}

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/converter/impl/ElvConverter.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/converter/impl/ElvConverter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Groupon, Inc
+ *
+ * Groupon licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.killbill.billing.plugin.adyen.client.payment.converter.impl;
 
 import org.killbill.adyen.payment.ELV;

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/converter/impl/PaymentInfoConverterService.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/converter/impl/PaymentInfoConverterService.java
@@ -33,7 +33,11 @@ public class PaymentInfoConverterService implements PaymentInfoConverterManageme
     private final List<PaymentInfoConverter<? extends PaymentInfo>> paymentInfoConverters;
 
     public PaymentInfoConverterService() {
-        this(ImmutableList.<PaymentInfoConverter<? extends PaymentInfo>>of(new CreditCardConverter()));
+        this(ImmutableList.<PaymentInfoConverter<? extends PaymentInfo>>of(
+                new CreditCardConverter(),
+                new AmexConverter(),
+                new SepaDirectDebitConverter(),
+                new ElvConverter()));
     }
 
     public PaymentInfoConverterService(final List<PaymentInfoConverter<? extends PaymentInfo>> paymentInfoConverterList) {

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/converter/impl/SepaDirectDebitConverter.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/converter/impl/SepaDirectDebitConverter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Groupon, Inc
+ *
+ * Groupon licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.killbill.billing.plugin.adyen.client.payment.converter.impl;
 
 import org.killbill.adyen.payment.BankAccount;

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/converter/impl/SepaDirectDebitConverter.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/converter/impl/SepaDirectDebitConverter.java
@@ -1,0 +1,56 @@
+package org.killbill.billing.plugin.adyen.client.payment.converter.impl;
+
+import org.killbill.adyen.payment.BankAccount;
+import org.killbill.adyen.payment.PaymentRequest;
+import org.killbill.billing.plugin.adyen.client.model.PaymentInfo;
+import org.killbill.billing.plugin.adyen.client.model.PaymentType;
+import org.killbill.billing.plugin.adyen.client.model.paymentinfo.Card;
+import org.killbill.billing.plugin.adyen.client.model.paymentinfo.SepaDirectDebit;
+import org.killbill.billing.plugin.adyen.client.payment.converter.PaymentInfoConverter;
+
+import static org.killbill.billing.plugin.adyen.client.model.PaymentType.SEPA_DIRECT_DEBIT;
+
+
+public class SepaDirectDebitConverter implements PaymentInfoConverter<SepaDirectDebit> {
+
+    private static final String SELECTED_BRAND_SEPA = "sepadirectdebit";
+
+    @Override
+    public Object convertPaymentInfoToPSPTransferObject(final String holderName, final SepaDirectDebit sepaDirectDebit) {
+        BankAccount bankAccount = new BankAccount();
+        bankAccount.setIban(sepaDirectDebit.getIban());
+        bankAccount.setBic(sepaDirectDebit.getBic());
+        bankAccount.setOwnerName(holderName(sepaDirectDebit, holderName));
+        bankAccount.setCountryCode(sepaDirectDebit.getCountryCode());
+        final PaymentRequest paymentRequest = new PaymentRequest();
+        paymentRequest.setBankAccount(bankAccount);
+        paymentRequest.setSelectedBrand(SELECTED_BRAND_SEPA);
+        return paymentRequest;
+    }
+
+    /**
+     * There is no 3DSecure for Sepa Direct Debit.
+     *
+     * @param billedAmount Billed amount.
+     * @param card {@link PaymentInfo} of type {@link Card}.
+     * @return Always {@literal null} for Sepa Direct Debit.
+     */
+    @Override
+    public Object convertPaymentInfoFor3DSecureAuth(final Long billedAmount, final Card card) {
+        return null;
+    }
+
+    @Override
+    public PaymentType getPaymentType() {
+        return SEPA_DIRECT_DEBIT;
+    }
+
+    private String holderName(final SepaDirectDebit sepaDirectDebit, final String holderName) {
+        if (sepaDirectDebit.getSepaAccountHolder() != null && !sepaDirectDebit.getSepaAccountHolder().isEmpty()) {
+            return sepaDirectDebit.getSepaAccountHolder();
+        } else {
+            return holderName;
+        }
+    }
+
+}

--- a/src/test/java/org/killbill/billing/plugin/adyen/TestRemoteBase.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/TestRemoteBase.java
@@ -58,6 +58,17 @@ public abstract class TestRemoteBase {
     protected static final int CC_EXPIRATION_MONTH = 8;
     protected static final int CC_EXPIRATION_YEAR = 2018;
     protected static final String CC_VERIFICATION_VALUE = "7373";
+    protected static final String CC_TYPE = "amex";
+
+    protected static final String DD_IBAN = "DE87123456781234567890";
+    protected static final String DD_BIC = "TESTDE01XXX";
+    protected static final String DD_HOLDER_NAME = "A. Schneider";
+    protected static final String DD_TYPE = "sepadirectdebit";
+
+    protected static final String ELV_ACCOUNT_NUMBER = "1234567890";
+    protected static final String ELV_BLZ = "12345678";
+    protected static final String ELV_HOLDER_NAME = "Bill Killson";
+    protected static final String ELV_TYPE = "elv";
 
     protected AdyenConfigProperties adyenConfigProperties;
     protected AdyenConfigurationHandler adyenConfigurationHandler;


### PR DESCRIPTION
Added support for [Sepa Direct Debit](https://docs.adyen.com/display/TD/SEPA+Direct+Debit) and German [ELV](https://en.wikipedia.org/wiki/Direct_debit#Germany) payments via Adyen.

- New `PaymentInfo` object `SepaDirectDebit` (`Elv` was already present)
- New `PaymentInfoConverter`s 
  - `SepaDirectDebitConverter`
  - `ElvConverter`
  - `AmexConverter` (needed for existing tests for credit card)
- `PaymentInfoConverter`s added to `PaymentInfoConverterService`
- Tests for SepaDirectDebit and ELV