### PR TITLE
Handle communication errors nicely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@
 .idea/dbnavigator.xml
 *.ipr
 *.iws
+# Mac #
+*.DS_Store
+
+.idea
 *.iml
 target
 

--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -27,30 +27,6 @@
             <package name="" withSubpackages="true" static="true" />
           </value>
         </option>
-        <DBN-PSQL>
-          <case-options enabled="false">
-            <option name="KEYWORD_CASE" value="lower" />
-            <option name="FUNCTION_CASE" value="lower" />
-            <option name="PARAMETER_CASE" value="lower" />
-            <option name="DATATYPE_CASE" value="lower" />
-            <option name="OBJECT_CASE" value="preserve" />
-          </case-options>
-          <formatting-settings enabled="false" />
-        </DBN-PSQL>
-        <DBN-SQL>
-          <case-options enabled="false">
-            <option name="KEYWORD_CASE" value="lower" />
-            <option name="FUNCTION_CASE" value="lower" />
-            <option name="PARAMETER_CASE" value="lower" />
-            <option name="DATATYPE_CASE" value="lower" />
-            <option name="OBJECT_CASE" value="preserve" />
-          </case-options>
-          <formatting-settings enabled="false">
-            <option name="STATEMENT_SPACING" value="one_line" />
-            <option name="CLAUSE_CHOP_DOWN" value="chop_down_if_statement_long" />
-            <option name="ITERATION_ELEMENTS_WRAPPING" value="chop_down_if_not_single" />
-          </formatting-settings>
-        </DBN-SQL>
         <XML>
           <option name="XML_ATTRIBUTE_WRAP" value="0" />
           <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,12 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>1.57</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentMethodPlugin.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentMethodPlugin.java
@@ -16,18 +16,18 @@
 
 package org.killbill.billing.plugin.adyen.api;
 
-import java.util.UUID;
-
 import org.killbill.billing.plugin.adyen.dao.AdyenDao;
 import org.killbill.billing.plugin.adyen.dao.gen.tables.records.AdyenPaymentMethodsRecord;
 import org.killbill.billing.plugin.api.payment.PluginPaymentMethodPlugin;
+
+import java.util.UUID;
 
 public class AdyenPaymentMethodPlugin extends PluginPaymentMethodPlugin {
 
     public AdyenPaymentMethodPlugin(final AdyenPaymentMethodsRecord record) {
         super(UUID.fromString(record.getKbPaymentMethodId()),
-              record.getToken(),
-              record.getIsDefault() == AdyenDao.TRUE,
-              AdyenModelPluginBase.buildPluginProperties(record.getAdditionalData()));
+                record.getToken(),
+                (record.getIsDefault() != null) && AdyenDao.TRUE == record.getIsDefault(),
+                AdyenModelPluginBase.buildPluginProperties(record.getAdditionalData()));
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentTransactionInfoPlugin.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentTransactionInfoPlugin.java
@@ -16,11 +16,9 @@
 
 package org.killbill.billing.plugin.adyen.api;
 
-import java.math.BigDecimal;
-import java.util.UUID;
-
-import javax.annotation.Nullable;
-
+import com.google.common.base.Optional;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.killbill.billing.catalog.api.Currency;
@@ -30,13 +28,16 @@ import org.killbill.billing.payment.plugin.api.PaymentPluginStatus;
 import org.killbill.billing.plugin.adyen.client.model.PaymentModificationResponse;
 import org.killbill.billing.plugin.adyen.client.model.PaymentServiceProviderResult;
 import org.killbill.billing.plugin.adyen.client.model.PurchaseResult;
-import org.killbill.billing.plugin.adyen.client.payment.exception.ModificationFailedException;
+import org.killbill.billing.plugin.adyen.client.payment.service.AdyenCallErrorStatus;
 import org.killbill.billing.plugin.adyen.dao.gen.tables.records.AdyenResponsesRecord;
 import org.killbill.billing.plugin.api.PluginProperties;
 import org.killbill.billing.plugin.api.payment.PluginPaymentTransactionInfoPlugin;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class AdyenPaymentTransactionInfoPlugin extends PluginPaymentTransactionInfoPlugin {
 
@@ -48,18 +49,18 @@ public class AdyenPaymentTransactionInfoPlugin extends PluginPaymentTransactionI
                                              final DateTime utcNow,
                                              final PaymentPluginStatus paymentPluginStatus) {
         super(kbPaymentId,
-              kbTransactionPaymentPaymentId,
-              transactionType,
-              amount,
-              currency,
-              paymentPluginStatus,
-              null,
-              null,
-              null,
-              null,
-              utcNow,
-              utcNow,
-              ImmutableList.<PluginProperty>of());
+                kbTransactionPaymentPaymentId,
+                transactionType,
+                amount,
+                currency,
+                paymentPluginStatus,
+                null,
+                null,
+                null,
+                null,
+                utcNow,
+                utcNow,
+                ImmutableList.<PluginProperty>of());
     }
 
     public AdyenPaymentTransactionInfoPlugin(final UUID kbPaymentId,
@@ -70,18 +71,18 @@ public class AdyenPaymentTransactionInfoPlugin extends PluginPaymentTransactionI
                                              final DateTime utcNow,
                                              final PurchaseResult purchaseResult) {
         super(kbPaymentId,
-              kbTransactionPaymentPaymentId,
-              transactionType,
-              amount,
-              currency,
-              getPaymentPluginStatus(purchaseResult.getResult()),
-              purchaseResult.getResultCode(),
-              purchaseResult.getReason(),
-              purchaseResult.getPspReference(),
-              purchaseResult.getAuthCode(),
-              utcNow,
-              utcNow,
-              PluginProperties.buildPluginProperties(purchaseResult.getFormParameter()));
+                kbTransactionPaymentPaymentId,
+                transactionType,
+                amount,
+                currency,
+                getPaymentPluginStatus(purchaseResult.getAdyenCallErrorStatus(), purchaseResult.getResult()),
+                purchaseResult.getResultCode(),
+                purchaseResult.getReason(),
+                purchaseResult.getPspReference(),
+                purchaseResult.getAuthCode(),
+                utcNow,
+                utcNow,
+                PluginProperties.buildPluginProperties(purchaseResult.getFormParameter()));
     }
 
     public AdyenPaymentTransactionInfoPlugin(final UUID kbPaymentId,
@@ -89,74 +90,71 @@ public class AdyenPaymentTransactionInfoPlugin extends PluginPaymentTransactionI
                                              final TransactionType transactionType,
                                              final BigDecimal amount,
                                              @Nullable final Currency currency,
-                                             final PaymentServiceProviderResult pspResult,
+                                             final Optional<PaymentServiceProviderResult> pspResult,
                                              final DateTime utcNow,
                                              final PaymentModificationResponse paymentModificationResponse) {
         super(kbPaymentId,
-              kbTransactionPaymentPaymentId,
-              transactionType,
-              amount,
-              currency,
-              getPaymentPluginStatus(pspResult),
-              paymentModificationResponse.getResponse(),
-              null,
-              paymentModificationResponse.getPspReference(),
-              null,
-              utcNow,
-              utcNow,
-              PluginProperties.buildPluginProperties(paymentModificationResponse.getAdditionalData()));
+                kbTransactionPaymentPaymentId,
+                transactionType,
+                amount,
+                currency,
+                getPaymentPluginStatus(paymentModificationResponse.getAdyenCallErrorStatus(), pspResult),
+                paymentModificationResponse.getResponse(),
+                null,
+                paymentModificationResponse.getPspReference(),
+                null,
+                utcNow,
+                utcNow,
+                PluginProperties.buildPluginProperties(paymentModificationResponse.getAdditionalData()));
     }
 
-    public AdyenPaymentTransactionInfoPlugin(final UUID kbPaymentId,
-                                             final UUID kbTransactionPaymentPaymentId,
-                                             final TransactionType transactionType,
-                                             final BigDecimal amount,
-                                             final Currency currency,
-                                             final PaymentServiceProviderResult pspResult,
-                                             final DateTime utcNow,
-                                             final ModificationFailedException e) {
-        super(kbPaymentId,
-              kbTransactionPaymentPaymentId,
-              transactionType,
-              amount,
-              currency,
-              getPaymentPluginStatus(pspResult),
-              e.getLocalizedMessage(),
-              null,
-              null,
-              null,
-              utcNow,
-              utcNow,
-              ImmutableList.<PluginProperty>of());
-    }
 
     public AdyenPaymentTransactionInfoPlugin(final AdyenResponsesRecord record) {
         super(UUID.fromString(record.getKbPaymentId()),
-              UUID.fromString(record.getKbPaymentTransactionId()),
-              TransactionType.valueOf(record.getTransactionType()),
-              record.getAmount(),
-              Strings.isNullOrEmpty(record.getCurrency()) ? null : Currency.valueOf(record.getCurrency()),
-              Strings.isNullOrEmpty(record.getPspResult()) ? PaymentPluginStatus.UNDEFINED : getPaymentPluginStatus(PaymentServiceProviderResult.getPaymentResultForId(record.getPspResult())),
-              record.getResultCode(),
-              record.getRefusalReason(),
-              record.getPspReference(),
-              record.getAuthCode(),
-              new DateTime(record.getCreatedDate(), DateTimeZone.UTC),
-              new DateTime(record.getCreatedDate(), DateTimeZone.UTC),
-              AdyenModelPluginBase.buildPluginProperties(record.getAdditionalData()));
+                UUID.fromString(record.getKbPaymentTransactionId()),
+                TransactionType.valueOf(record.getTransactionType()),
+                record.getAmount(),
+                Strings.isNullOrEmpty(record.getCurrency()) ? null : Currency.valueOf(record.getCurrency()),
+                Strings.isNullOrEmpty(record.getPspResult())
+                        ? PaymentPluginStatus.UNDEFINED
+                        : getPaymentPluginStatus(Optional.of(AdyenCallErrorStatus.UNKNOWN_FAILURE),
+                        Optional.of(PaymentServiceProviderResult.getPaymentResultForId(record.getPspResult()))),
+                record.getResultCode(),
+                record.getRefusalReason(),
+                record.getPspReference(),
+                record.getAuthCode(),
+                new DateTime(record.getCreatedDate(), DateTimeZone.UTC),
+                new DateTime(record.getCreatedDate(), DateTimeZone.UTC),
+                AdyenModelPluginBase.buildPluginProperties(record.getAdditionalData()));
     }
 
-    @Override
-    public PaymentPluginStatus getStatus() {
-        final String hppTransactionStatus = PluginProperties.findPluginPropertyValue(AdyenPaymentPluginApi.PROPERTY_FROM_HPP_TRANSACTION_STATUS, getProperties());
-        if (hppTransactionStatus != null) {
-            return PaymentPluginStatus.valueOf(hppTransactionStatus);
-        } else {
-            return super.getStatus();
+    /**
+     * Transforms adyenCallErrorStatus (where there any technical errors?) and pspResult (was the call successful from a business perspective) into the PaymentPluginStatus.
+     * Therefor
+     */
+    private static PaymentPluginStatus getPaymentPluginStatus(final Optional<AdyenCallErrorStatus> adyenCallErrorStatus, final Optional<PaymentServiceProviderResult> pspResult) {
+        checkArgument(adyenCallErrorStatus.isPresent() ^ pspResult.isPresent());
+        return (pspResult.isPresent()) ? pspResultToPaymentPluginStatus(pspResult.get()) : adyenCallErrorStatusToPaymentPluginStatus(adyenCallErrorStatus.get());
+    }
+
+    private static PaymentPluginStatus adyenCallErrorStatusToPaymentPluginStatus(AdyenCallErrorStatus adyenCallErrorStatus) {
+        switch (adyenCallErrorStatus) {
+            case REQUEST_NOT_SEND:
+                return PaymentPluginStatus.CANCELED;
+            case RESPONSE_ABOUT_INVALID_REQUEST:
+                return PaymentPluginStatus.ERROR;
+            case RESPONSE_NOT_RECEIVED:
+                return PaymentPluginStatus.UNDEFINED;
+            case RESPONSE_INVALID:
+                return PaymentPluginStatus.UNDEFINED;
+            case UNKNOWN_FAILURE:
+                return PaymentPluginStatus.UNDEFINED;
+            default:
+                return PaymentPluginStatus.UNDEFINED;
         }
     }
 
-    private static PaymentPluginStatus getPaymentPluginStatus(final PaymentServiceProviderResult pspResult) {
+    private static PaymentPluginStatus pspResultToPaymentPluginStatus(PaymentServiceProviderResult pspResult) {
         switch (pspResult) {
             case INITIALISED:
             case REDIRECT_SHOPPER:
@@ -167,10 +165,21 @@ public class AdyenPaymentTransactionInfoPlugin extends PluginPaymentTransactionI
                 return PaymentPluginStatus.PROCESSED;
             case REFUSED:
             case ERROR:
+                return PaymentPluginStatus.ERROR;
             case CANCELLED:
                 return PaymentPluginStatus.ERROR;
             default:
                 return PaymentPluginStatus.UNDEFINED;
+        }
+    }
+
+    @Override
+    public PaymentPluginStatus getStatus() {
+        final String hppTransactionStatus = PluginProperties.findPluginPropertyValue(AdyenPaymentPluginApi.PROPERTY_FROM_HPP_TRANSACTION_STATUS, getProperties());
+        if (hppTransactionStatus != null) {
+            return PaymentPluginStatus.valueOf(hppTransactionStatus);
+        } else {
+            return super.getStatus();
         }
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/AdyenConfigProperties.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/AdyenConfigProperties.java
@@ -16,12 +16,12 @@
 
 package org.killbill.billing.plugin.adyen.client;
 
+import com.google.common.base.Strings;
+
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
-
-import com.google.common.base.Strings;
 
 public class AdyenConfigProperties {
 
@@ -58,6 +58,8 @@ public class AdyenConfigProperties {
     private final String acquirersList;
     private final String defaultAcquirer;
     private final String defaultCountryIsoCode;
+    private final String paymentConnectionTimeout;
+    private final String paymentReadTimeout;
 
     public AdyenConfigProperties(final Properties properties) {
         this.allowChunking = properties.getProperty(PROPERTY_PREFIX + "allowChunking");
@@ -74,6 +76,9 @@ public class AdyenConfigProperties {
         this.acquirersList = properties.getProperty(PROPERTY_PREFIX + "acquirersList");
         this.defaultAcquirer = properties.getProperty(PROPERTY_PREFIX + "defaultAcquirer");
         this.defaultCountryIsoCode = properties.getProperty(PROPERTY_PREFIX + "defaultCountryIsoCode");
+
+        this.paymentConnectionTimeout = properties.getProperty(PROPERTY_PREFIX + "paymentConnectionTimeout");
+        this.paymentReadTimeout = properties.getProperty(PROPERTY_PREFIX + "paymentReadTimeout");
 
         this.hmacSecrets = properties.getProperty(PROPERTY_PREFIX + "hmac.secret");
         refillMap(secretMap, hmacSecrets);
@@ -242,5 +247,13 @@ public class AdyenConfigProperties {
                 map.put(entry.split("#")[0], entry.split(KEY_VALUE_DELIMITER)[1]);
             }
         }
+    }
+
+    public String getPaymentConnectionTimeout() {
+        return paymentConnectionTimeout;
+    }
+
+    public String getPaymentReadTimeout() {
+        return paymentReadTimeout;
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/model/PaymentModificationResponse.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/model/PaymentModificationResponse.java
@@ -16,6 +16,9 @@
 
 package org.killbill.billing.plugin.adyen.client.model;
 
+import com.google.common.base.Optional;
+import org.killbill.billing.plugin.adyen.client.payment.service.AdyenCallErrorStatus;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -24,6 +27,7 @@ public class PaymentModificationResponse {
     private Map<Object, Object> additionalData;
     private String pspReference;
     private String response;
+    private Optional<AdyenCallErrorStatus> adyenCallErrorStatus = Optional.absent();
 
     public PaymentModificationResponse(final String response, final String pspReference, final Map<Object, Object> additionalData) {
         this.additionalData = additionalData;
@@ -31,12 +35,19 @@ public class PaymentModificationResponse {
         this.response = response;
     }
 
+    public PaymentModificationResponse(final String pspReference, final AdyenCallErrorStatus adyenCallErrorStatus) {
+        this.pspReference = pspReference;
+        this.adyenCallErrorStatus = Optional.of(adyenCallErrorStatus);
+    }
+
     public PaymentModificationResponse(final String response, final String pspReference) {
         this(response, pspReference, new HashMap<Object, Object>());
     }
 
-    public PaymentModificationResponse() {
+    public boolean isSuccess() {
+        return !adyenCallErrorStatus.isPresent();
     }
+
 
     public Map<Object, Object> getAdditionalData() {
         return additionalData;
@@ -62,38 +73,24 @@ public class PaymentModificationResponse {
         this.response = response;
     }
 
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("PaymentModificationResponse{");
-        sb.append("additionalData=").append(additionalData);
-        sb.append(", pspReference='").append(pspReference).append('\'');
-        sb.append(", response='").append(response).append('\'');
-        sb.append('}');
-        return sb.toString();
+    public Optional<AdyenCallErrorStatus> getAdyenCallErrorStatus() {
+        return adyenCallErrorStatus;
     }
 
     @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
-        final PaymentModificationResponse that = (PaymentModificationResponse) o;
+        PaymentModificationResponse that = (PaymentModificationResponse) o;
 
-        if (additionalData != null ? !additionalData.equals(that.additionalData) : that.additionalData != null) {
+        if (additionalData != null ? !additionalData.equals(that.additionalData) : that.additionalData != null)
             return false;
-        }
-        if (pspReference != null ? !pspReference.equals(that.pspReference) : that.pspReference != null) {
-            return false;
-        }
-        if (response != null ? !response.equals(that.response) : that.response != null) {
-            return false;
-        }
+        if (pspReference != null ? !pspReference.equals(that.pspReference) : that.pspReference != null) return false;
+        //noinspection SimplifiableIfStatement
+        if (response != null ? !response.equals(that.response) : that.response != null) return false;
+        return !(adyenCallErrorStatus != null ? !adyenCallErrorStatus.equals(that.adyenCallErrorStatus) : that.adyenCallErrorStatus != null);
 
-        return true;
     }
 
     @Override
@@ -101,6 +98,17 @@ public class PaymentModificationResponse {
         int result = additionalData != null ? additionalData.hashCode() : 0;
         result = 31 * result + (pspReference != null ? pspReference.hashCode() : 0);
         result = 31 * result + (response != null ? response.hashCode() : 0);
+        result = 31 * result + (adyenCallErrorStatus != null ? adyenCallErrorStatus.hashCode() : 0);
         return result;
+    }
+
+    @Override
+    public String toString() {
+        return "PaymentModificationResponse{" +
+                "additionalData=" + additionalData +
+                ", pspReference='" + pspReference + '\'' +
+                ", response='" + response + '\'' +
+                ", adyenCallErrorStatus=" + adyenCallErrorStatus +
+                '}';
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/model/PurchaseResult.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/model/PurchaseResult.java
@@ -16,18 +16,19 @@
 
 package org.killbill.billing.plugin.adyen.client.model;
 
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.killbill.billing.plugin.adyen.client.payment.service.AdyenCallErrorStatus;
+
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
-
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-
 public class PurchaseResult extends FrontendForm {
 
-    private final PaymentServiceProviderResult result;
+    private final Optional<PaymentServiceProviderResult> result;
     private final String authCode;
     private final String pspReference;
     private final String reason;
@@ -35,13 +36,11 @@ public class PurchaseResult extends FrontendForm {
     private final String reference;
     private final List<PaymentServiceProviderErrorCodes> errorCodes;
     private final String paymentInternalRef;
+    private final AdyenCallErrorStatus adyenCallErrorStatus;
 
-    public PurchaseResult(final PaymentServiceProviderResult result,
-                          final String reason,
-                          final String reference,
-                          final List<PaymentServiceProviderErrorCodes> errorCodes,
-                          final String paymentInternalRef) {
-        this(result, null, null, reason, null, reference, errorCodes, paymentInternalRef, null, null);
+    public PurchaseResult(final String paymentInternalRef,
+                          final AdyenCallErrorStatus adyenCallErrorStatus) {
+        this(Optional.<PaymentServiceProviderResult>absent(), null, null, null, null, null, ImmutableList.<PaymentServiceProviderErrorCodes>of(), paymentInternalRef, null, null, adyenCallErrorStatus);
     }
 
     public PurchaseResult(final PaymentServiceProviderResult result,
@@ -52,7 +51,7 @@ public class PurchaseResult extends FrontendForm {
                           final String paymentInternalRef,
                           final String formUrl,
                           final Map<String, String> formParameter) {
-        this(result, authCode, pspReference, reason, resultCode, null, null, paymentInternalRef, formUrl, formParameter);
+        this(Optional.of(result), authCode, pspReference, reason, resultCode, null, null, paymentInternalRef, formUrl, formParameter, null);
     }
 
     public PurchaseResult(final PaymentServiceProviderResult result,
@@ -61,10 +60,10 @@ public class PurchaseResult extends FrontendForm {
                           final String reason,
                           final String resultCode,
                           final String paymentInternalRef) {
-        this(result, authCode, pspReference, reason, resultCode, null, null, paymentInternalRef, null, null);
+        this(Optional.of(result), authCode, pspReference, reason, resultCode, null, null, paymentInternalRef, null, null, null);
     }
 
-    private PurchaseResult(@Nullable final PaymentServiceProviderResult result,
+    private PurchaseResult(final Optional<PaymentServiceProviderResult> result,
                            final String authCode,
                            final String pspReference,
                            final String reason,
@@ -73,14 +72,16 @@ public class PurchaseResult extends FrontendForm {
                            @Nullable final List<PaymentServiceProviderErrorCodes> errorCodes,
                            final String paymentInternalRef,
                            final String formUrl,
-                           final Map<String, String> formParameter) {
+                           final Map<String, String> formParameter,
+                           AdyenCallErrorStatus adyenCallErrorStatus) {
         super(MoreObjects.firstNonNull(formParameter, ImmutableMap.<String, String>of()), formUrl);
 
-        this.result = MoreObjects.firstNonNull(result, PaymentServiceProviderResult.REDIRECT_SHOPPER);
+        this.adyenCallErrorStatus = adyenCallErrorStatus;
+        this.result = result;
         this.authCode = authCode;
         this.pspReference = pspReference;
         this.reason = reason;
-        this.resultCode = MoreObjects.firstNonNull(resultCode, this.result.getId());
+        this.resultCode = resultCode;
         this.reference = reference;
         this.errorCodes = MoreObjects.firstNonNull(errorCodes, ImmutableList.<PaymentServiceProviderErrorCodes>of());
         this.paymentInternalRef = paymentInternalRef;
@@ -102,7 +103,7 @@ public class PurchaseResult extends FrontendForm {
         return reason;
     }
 
-    public PaymentServiceProviderResult getResult() {
+    public Optional<PaymentServiceProviderResult> getResult() {
         return result;
     }
 
@@ -118,58 +119,29 @@ public class PurchaseResult extends FrontendForm {
         return errorCodes;
     }
 
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("PurchaseResult{");
-        sb.append("result=").append(result);
-        sb.append(", authCode='").append(authCode).append('\'');
-        sb.append(", pspReference='").append(pspReference).append('\'');
-        sb.append(", reason='").append(reason).append('\'');
-        sb.append(", resultCode='").append(resultCode).append('\'');
-        sb.append(", reference='").append(reference).append('\'');
-        sb.append(", errorCodes=").append(errorCodes);
-        sb.append(", paymentInternalRef='").append(paymentInternalRef).append('\'');
-        sb.append('}');
-        return sb.toString();
+    public Optional<AdyenCallErrorStatus> getAdyenCallErrorStatus() {
+        return Optional.fromNullable(adyenCallErrorStatus);
     }
 
     @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
-        final PurchaseResult that = (PurchaseResult) o;
+        PurchaseResult that = (PurchaseResult) o;
 
-        if (authCode != null ? !authCode.equals(that.authCode) : that.authCode != null) {
+        if (result != null ? !result.equals(that.result) : that.result != null) return false;
+        if (authCode != null ? !authCode.equals(that.authCode) : that.authCode != null) return false;
+        if (pspReference != null ? !pspReference.equals(that.pspReference) : that.pspReference != null) return false;
+        if (reason != null ? !reason.equals(that.reason) : that.reason != null) return false;
+        if (resultCode != null ? !resultCode.equals(that.resultCode) : that.resultCode != null) return false;
+        if (reference != null ? !reference.equals(that.reference) : that.reference != null) return false;
+        if (errorCodes != null ? !errorCodes.equals(that.errorCodes) : that.errorCodes != null) return false;
+        //noinspection SimplifiableIfStatement
+        if (paymentInternalRef != null ? !paymentInternalRef.equals(that.paymentInternalRef) : that.paymentInternalRef != null)
             return false;
-        }
-        if (errorCodes != null ? !errorCodes.equals(that.errorCodes) : that.errorCodes != null) {
-            return false;
-        }
-        if (paymentInternalRef != null ? !paymentInternalRef.equals(that.paymentInternalRef) : that.paymentInternalRef != null) {
-            return false;
-        }
-        if (pspReference != null ? !pspReference.equals(that.pspReference) : that.pspReference != null) {
-            return false;
-        }
-        if (reason != null ? !reason.equals(that.reason) : that.reason != null) {
-            return false;
-        }
-        if (reference != null ? !reference.equals(that.reference) : that.reference != null) {
-            return false;
-        }
-        if (result != that.result) {
-            return false;
-        }
-        if (resultCode != null ? !resultCode.equals(that.resultCode) : that.resultCode != null) {
-            return false;
-        }
+        return adyenCallErrorStatus == that.adyenCallErrorStatus;
 
-        return true;
     }
 
     @Override
@@ -182,6 +154,22 @@ public class PurchaseResult extends FrontendForm {
         result1 = 31 * result1 + (reference != null ? reference.hashCode() : 0);
         result1 = 31 * result1 + (errorCodes != null ? errorCodes.hashCode() : 0);
         result1 = 31 * result1 + (paymentInternalRef != null ? paymentInternalRef.hashCode() : 0);
+        result1 = 31 * result1 + (adyenCallErrorStatus != null ? adyenCallErrorStatus.hashCode() : 0);
         return result1;
+    }
+
+    @Override
+    public String toString() {
+        return "PurchaseResult{" +
+                "result=" + result +
+                ", authCode='" + authCode + '\'' +
+                ", pspReference='" + pspReference + '\'' +
+                ", reason='" + reason + '\'' +
+                ", resultCode='" + resultCode + '\'' +
+                ", reference='" + reference + '\'' +
+                ", errorCodes=" + errorCodes +
+                ", paymentInternalRef='" + paymentInternalRef + '\'' +
+                ", adyenResponseStatus=" + adyenCallErrorStatus +
+                '}';
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/AdyenCallErrorStatus.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/AdyenCallErrorStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Groupon, Inc
+ * Copyright 2015 Groupon, Inc
  *
  * Groupon licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -13,12 +13,13 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+package org.killbill.billing.plugin.adyen.client.payment.service;
 
-package org.killbill.billing.plugin.adyen.client.payment.exception;
 
-public class ModificationFailedException extends Exception {
-
-    public ModificationFailedException(final Throwable t) {
-        super(t);
-    }
+public enum AdyenCallErrorStatus {
+    REQUEST_NOT_SEND,
+    RESPONSE_ABOUT_INVALID_REQUEST,
+    RESPONSE_NOT_RECEIVED,
+    RESPONSE_INVALID,
+    UNKNOWN_FAILURE
 }

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/AdyenCallResult.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/AdyenCallResult.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2015 Groupon, Inc
+ *
+ * Groupon licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.killbill.billing.plugin.adyen.client.payment.service;
+
+import com.google.common.base.Optional;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public interface AdyenCallResult<T> {
+    Optional<T> getResult();
+
+    Optional<AdyenCallErrorStatus> getResponseStatus();
+
+    boolean receivedWellFormedResponse();
+
+    Optional<String> getErrorMessage();
+
+}
+
+class SuccessfulAdyenCall<T> implements AdyenCallResult<T> {
+
+    private final T result;
+
+    public SuccessfulAdyenCall(T result) {
+
+        checkNotNull(result, "result");
+
+        this.result = result;
+    }
+
+    @Override
+    public Optional<T> getResult() {
+        return Optional.of(result);
+    }
+
+    @Override
+    public Optional<AdyenCallErrorStatus> getResponseStatus() {
+        return Optional.absent();
+    }
+
+    @Override
+    public boolean receivedWellFormedResponse() {
+        return true;
+    }
+
+    @Override
+    public Optional<String> getErrorMessage() {
+        return Optional.absent();
+    }
+
+    @Override
+    public String toString() {
+        return "SuccessfulAdyenCall{" +
+                "result=" + result +
+                '}';
+    }
+}
+
+class UnSuccessfulAdyenCall<T> implements AdyenCallResult<T> {
+
+
+    private final AdyenCallErrorStatus responseStatus;
+    private final String errorMessage;
+
+    UnSuccessfulAdyenCall(AdyenCallErrorStatus responseStatus, String errorMessage) {
+        this.responseStatus = responseStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public Optional<T> getResult() {
+        return Optional.absent();
+    }
+
+    @Override
+    public Optional<AdyenCallErrorStatus> getResponseStatus() {
+        return Optional.of(responseStatus);
+    }
+
+    @Override
+    public boolean receivedWellFormedResponse() {
+        return false;
+    }
+
+    @Override
+    public Optional<String> getErrorMessage() {
+        return Optional.of(errorMessage);
+    }
+
+    @Override
+    public String toString() {
+        return "UnSuccessfulAdyenCall{" +
+                "responseStatus=" + responseStatus +
+                ", errorMessage='" + errorMessage + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/AdyenPaymentRequestSender.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/AdyenPaymentRequestSender.java
@@ -16,9 +16,10 @@
 
 package org.killbill.billing.plugin.adyen.client.payment.service;
 
-import java.io.Closeable;
-import java.io.IOException;
-
+import com.ctc.wstx.exc.WstxEOFException;
+import com.google.common.base.Throwables;
+import org.apache.cxf.binding.soap.SoapFault;
+import org.apache.cxf.transport.http.HTTPException;
 import org.killbill.adyen.payment.DirectDebitRequest;
 import org.killbill.adyen.payment.DirectDebitResponse;
 import org.killbill.adyen.payment.ModificationRequest;
@@ -29,8 +30,20 @@ import org.killbill.adyen.payment.PaymentRequest3D;
 import org.killbill.adyen.payment.PaymentResult;
 import org.killbill.adyen.payment.ServiceException;
 import org.killbill.billing.plugin.adyen.client.PaymentPortRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.xml.ws.soap.SOAPFaultException;
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+
+import static org.killbill.billing.plugin.adyen.client.payment.service.AdyenCallErrorStatus.*;
 
 public class AdyenPaymentRequestSender implements Closeable {
+
+    private final static Logger logger = LoggerFactory.getLogger("adyen.sender");
 
     private final PaymentPortRegistry adyenPaymentPortRegistry;
 
@@ -38,40 +51,133 @@ public class AdyenPaymentRequestSender implements Closeable {
         this.adyenPaymentPortRegistry = adyenPaymentPortRegistry;
     }
 
-    public DirectDebitResponse directdebit(final String countryIsoCode, final DirectDebitRequest request) throws ServiceException {
-        return adyenPaymentPortRegistry.getPaymentPort(countryIsoCode).directdebit(request);
+    @SuppressWarnings("unused")
+    public AdyenCallResult<DirectDebitResponse> directdebit(final String countryIsoCode, final DirectDebitRequest request) {
+        return callAdyen(countryIsoCode, new AdyenCall<PaymentPortType, DirectDebitResponse>() {
+            @Override
+            public DirectDebitResponse apply(PaymentPortType paymentPort) throws ServiceException {
+                return paymentPort.directdebit(request);
+            }
+        });
     }
 
-    public PaymentResult authorise(final String countryIsoCode, final PaymentRequest request) throws ServiceException {
-        return adyenPaymentPortRegistry.getPaymentPort(countryIsoCode).authorise(request);
+    public AdyenCallResult<PaymentResult> authorise(final String countryIsoCode, final PaymentRequest request) {
+        return callAdyen(countryIsoCode, new AdyenCall<PaymentPortType, PaymentResult>() {
+            @Override
+            public PaymentResult apply(PaymentPortType paymentPort) throws ServiceException {
+                return paymentPort.authorise(request);
+            }
+        });
     }
 
-    public PaymentResult authorise3D(final String countryIsoCode, final PaymentRequest3D request) throws ServiceException {
-        return adyenPaymentPortRegistry.getPaymentPort(countryIsoCode).authorise3D(request);
+    public AdyenCallResult<PaymentResult> authorise3D(final String countryIsoCode, final PaymentRequest3D request) {
+        return callAdyen(countryIsoCode, new AdyenCall<PaymentPortType, PaymentResult>() {
+            @Override
+            public PaymentResult apply(PaymentPortType paymentPort) throws ServiceException {
+                return paymentPort.authorise3D(request);
+            }
+        });
     }
 
-    public ModificationResult refund(final String countryIsoCode, final ModificationRequest modificationRequest) throws ServiceException {
-        final PaymentPortType paymentPort = adyenPaymentPortRegistry.getPaymentPort(countryIsoCode);
-        return paymentPort.refund(modificationRequest);
+    public AdyenCallResult<ModificationResult> refund(final String countryIsoCode, final ModificationRequest modificationRequest) {
+        return callAdyen(countryIsoCode, new AdyenCall<PaymentPortType, ModificationResult>() {
+            @Override
+            public ModificationResult apply(PaymentPortType paymentPort) throws ServiceException {
+                return paymentPort.refund(modificationRequest);
+            }
+        });
     }
 
-    public ModificationResult cancel(final String countryIsoCode, final ModificationRequest modificationRequest) throws ServiceException {
-        final PaymentPortType paymentPort = adyenPaymentPortRegistry.getPaymentPort(countryIsoCode);
-        return paymentPort.cancel(modificationRequest);
+    public AdyenCallResult<ModificationResult> cancel(final String countryIsoCode, final ModificationRequest modificationRequest) {
+        return callAdyen(countryIsoCode, new AdyenCall<PaymentPortType, ModificationResult>() {
+            @Override
+            public ModificationResult apply(PaymentPortType paymentPort) throws ServiceException {
+                return paymentPort.cancel(modificationRequest);
+            }
+        });
     }
 
-    public ModificationResult cancelOrRefund(final String countryIsoCode, final ModificationRequest modificationRequest) throws ServiceException {
-        final PaymentPortType paymentPort = adyenPaymentPortRegistry.getPaymentPort(countryIsoCode);
-        return paymentPort.cancelOrRefund(modificationRequest);
+    public AdyenCallResult<ModificationResult> cancelOrRefund(final String countryIsoCode, final ModificationRequest modificationRequest) {
+        return callAdyen(countryIsoCode, new AdyenCall<PaymentPortType, ModificationResult>() {
+            @Override
+            public ModificationResult apply(PaymentPortType paymentPort) throws ServiceException {
+                return paymentPort.cancelOrRefund(modificationRequest);
+            }
+        });
     }
 
-    public ModificationResult capture(final String countryIsoCode, final ModificationRequest modificationRequest) throws ServiceException {
-        final PaymentPortType paymentPort = adyenPaymentPortRegistry.getPaymentPort(countryIsoCode);
-        return paymentPort.capture(modificationRequest);
+    public AdyenCallResult<ModificationResult> capture(final String countryIsoCode, final ModificationRequest modificationRequest) {
+        return callAdyen(countryIsoCode, new AdyenCall<PaymentPortType, ModificationResult>() {
+            @Override
+            public ModificationResult apply(PaymentPortType paymentPort) throws ServiceException {
+                return paymentPort.capture(modificationRequest);
+            }
+        });
+    }
+
+    private <T> AdyenCallResult<T> callAdyen(String countryIsoCode, AdyenCall<PaymentPortType, T> adyenCall) {
+        try {
+            PaymentPortType paymentPort = adyenPaymentPortRegistry.getPaymentPort(countryIsoCode);
+            T result = adyenCall.apply(paymentPort);
+            return new SuccessfulAdyenCall<T>(result);
+        } catch (Exception e) {
+            logger.info("exception during adyen reqeust", e);
+            return mapExceptionToCallResult(e);
+        }
+    }
+
+    /**
+     * Educated guess approach to transform CXF exceptions into error status codes.
+     * In the future if we encounter further different cases it makes sense to change this if/else structure to a map with lookups.
+     */
+    private <T> AdyenCallResult<T> mapExceptionToCallResult(Exception e) {
+        //noinspection ThrowableResultOfMethodCallIgnored
+        Throwable rootCause = Throwables.getRootCause(e);
+        if (rootCause instanceof SocketTimeoutException) {
+            // read timeout
+            if (rootCause.getMessage().contains("Read timed out")) {
+                return new UnSuccessfulAdyenCall<T>(RESPONSE_NOT_RECEIVED, e.getMessage());
+            } else if (rootCause.getMessage().contains("Unexpected end of file from server")) {
+                return new UnSuccessfulAdyenCall<T>(RESPONSE_INVALID, rootCause.getMessage());
+            }
+        } else if (rootCause instanceof SocketException) {
+            if (rootCause.getMessage().contains("Unexpected end of file from server")) {
+                return new UnSuccessfulAdyenCall<T>(RESPONSE_INVALID, e.getMessage());
+            }
+        } else if (rootCause instanceof HTTPException) {
+            // connection timeout
+            if (((HTTPException) rootCause).getResponseCode() == 503) {
+                return new UnSuccessfulAdyenCall<T>(REQUEST_NOT_SEND, rootCause.getMessage());
+            }
+            // e.g. different response code or strange response
+            return new UnSuccessfulAdyenCall<T>(RESPONSE_INVALID, rootCause.getMessage());
+        } else if (rootCause instanceof SOAPFaultException) {
+            return new UnSuccessfulAdyenCall<T>(RESPONSE_INVALID, e.getMessage());
+        } else if (rootCause instanceof IOException) {
+            if (rootCause.getMessage().contains("Invalid Http response")) {
+                // unparsable data as response
+                return new UnSuccessfulAdyenCall<T>(RESPONSE_INVALID, e.getMessage());
+            } else if (rootCause.getMessage().contains("Bogus chunk size")) {
+                return new UnSuccessfulAdyenCall<T>(RESPONSE_INVALID, e.getMessage());
+            }
+        } else if (rootCause instanceof WstxEOFException) {
+            // happens for example when 301 with empty body is returned...
+            return new UnSuccessfulAdyenCall<T>(RESPONSE_INVALID, e.getMessage());
+        } else if (rootCause instanceof SoapFault) {
+            return new UnSuccessfulAdyenCall<T>(RESPONSE_ABOUT_INVALID_REQUEST, e.getMessage());
+        }
+
+        logger.info("unknown exception will be mapped to UNKNOWN_FAILURE", e);
+        return new UnSuccessfulAdyenCall<T>(UNKNOWN_FAILURE, e.getMessage());
     }
 
     @Override
     public void close() throws IOException {
         adyenPaymentPortRegistry.close();
+    }
+
+
+    private interface AdyenCall<T, R> {
+        R apply(T t) throws ServiceException;
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/AdyenPaymentServiceProviderPort.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/AdyenPaymentServiceProviderPort.java
@@ -13,17 +13,10 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package org.killbill.billing.plugin.adyen.client.payment.service;
 
-import java.io.Closeable;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.xml.ws.soap.SOAPFaultException;
-
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import org.killbill.adyen.common.BrowserInfo;
 import org.killbill.adyen.payment.AnyType2AnyTypeMap;
 import org.killbill.adyen.payment.ModificationRequest;
@@ -31,39 +24,27 @@ import org.killbill.adyen.payment.ModificationResult;
 import org.killbill.adyen.payment.PaymentRequest;
 import org.killbill.adyen.payment.PaymentRequest3D;
 import org.killbill.adyen.payment.PaymentResult;
-import org.killbill.adyen.payment.ServiceException;
 import org.killbill.billing.plugin.adyen.api.AdyenPaymentPluginApi;
-import org.killbill.billing.plugin.adyen.client.model.OrderData;
-import org.killbill.billing.plugin.adyen.client.model.PaymentData;
-import org.killbill.billing.plugin.adyen.client.model.PaymentInfo;
-import org.killbill.billing.plugin.adyen.client.model.PaymentModificationResponse;
-import org.killbill.billing.plugin.adyen.client.model.PaymentProvider;
-import org.killbill.billing.plugin.adyen.client.model.PaymentServiceProviderResult;
-import org.killbill.billing.plugin.adyen.client.model.PurchaseResult;
-import org.killbill.billing.plugin.adyen.client.model.SplitSettlementData;
-import org.killbill.billing.plugin.adyen.client.model.UserData;
+import org.killbill.billing.plugin.adyen.client.model.*;
 import org.killbill.billing.plugin.adyen.client.model.paymentinfo.Card;
 import org.killbill.billing.plugin.adyen.client.payment.builder.AdyenRequestFactory;
 import org.killbill.billing.plugin.adyen.client.payment.converter.PaymentInfoConverterManagement;
-import org.killbill.billing.plugin.adyen.client.payment.exception.ModificationFailedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class AdyenPaymentServiceProviderPort implements Closeable {
 
-    private final static Logger logger = LoggerFactory.getLogger("adyen");
+    private final static Logger logger = LoggerFactory.getLogger("adyen.port");
 
     private final PaymentInfoConverterManagement paymentInfoConverterManagement;
     private final AdyenRequestFactory adyenRequestFactory;
     private final AdyenPaymentRequestSender adyenPaymentRequestSender;
-
-    /**
-     * received error constants *
-     */
-    private final static String REFUSED_FAILURE = "Refused";
 
     public AdyenPaymentServiceProviderPort(final PaymentInfoConverterManagement paymentInfoConverterManagement,
                                            final AdyenRequestFactory adyenRequestFactory,
@@ -100,50 +81,54 @@ public class AdyenPaymentServiceProviderPort implements Closeable {
 
     @VisibleForTesting
     PurchaseResult authorise(final PaymentRequest request, final String countryIsoCode, final PaymentData paymentData, final String termUrl) {
-        try {
-            final PaymentResult result = adyenPaymentRequestSender.authorise(countryIsoCode, request);
+        AdyenCallResult<PaymentResult> adyenCallResult = adyenPaymentRequestSender.authorise(countryIsoCode, request);
 
-            final PurchaseResult purchaseResult;
-            final PaymentServiceProviderResult paymentServiceProviderResult = PaymentServiceProviderResult.getPaymentResultForId(result.getResultCode());
-            if (paymentServiceProviderResult != PaymentServiceProviderResult.REDIRECT_SHOPPER) {
-                purchaseResult = new PurchaseResult(paymentServiceProviderResult,
-                                                    result.getAuthCode(),
-                                                    result.getPspReference(),
-                                                    result.getRefusalReason(),
-                                                    result.getResultCode(),
-                                                    paymentData.getPaymentInternalRef());
-            } else {
-                final Map<String, String> formParams = new HashMap<String, String>();
-                formParams.put(AdyenPaymentPluginApi.PROPERTY_PA_REQ, result.getPaRequest());
-                formParams.put(AdyenPaymentPluginApi.PROPERTY_MD, result.getMd());
-                formParams.put(AdyenPaymentPluginApi.PROPERTY_DCC_AMOUNT_VALUE, result.getDccAmount() == null ? null : String.valueOf(result.getDccAmount().getValue()));
-                formParams.put(AdyenPaymentPluginApi.PROPERTY_DCC_AMOUNT_CURRENCY, result.getDccAmount() == null ? null : result.getDccAmount().getCurrency());
-                formParams.put(AdyenPaymentPluginApi.PROPERTY_DCC_SIGNATURE, result.getDccSignature());
-                formParams.put(AdyenPaymentPluginApi.PROPERTY_ISSUER_URL, result.getIssuerUrl());
-                formParams.putAll(extractMpiAdditionalData(result));
-                if (termUrl != null) {
-                    formParams.put(AdyenPaymentPluginApi.PROPERTY_TERM_URL, termUrl);
-                }
+        if (!adyenCallResult.receivedWellFormedResponse()) {
+            return handleTechnicalFailureAtPurchase("authorize", paymentData, adyenCallResult);
+        }
 
-                purchaseResult = new PurchaseResult(paymentServiceProviderResult,
-                                                    result.getAuthCode(),
-                                                    result.getPspReference(),
-                                                    result.getRefusalReason(),
-                                                    result.getResultCode(),
-                                                    paymentData.getPaymentInternalRef(),
-                                                    result.getIssuerUrl(),
-                                                    formParams);
+        logger.info("received adyen authorize response: {}", adyenCallResult);
+        PaymentResult result = adyenCallResult.getResult().get();
+        final PurchaseResult purchaseResult;
+        final PaymentServiceProviderResult paymentServiceProviderResult = PaymentServiceProviderResult.getPaymentResultForId(result.getResultCode());
+        if (paymentServiceProviderResult != PaymentServiceProviderResult.REDIRECT_SHOPPER) {
+            purchaseResult = new PurchaseResult(paymentServiceProviderResult,
+                    result.getAuthCode(),
+                    result.getPspReference(),
+                    result.getRefusalReason(),
+                    result.getResultCode(),
+                    paymentData.getPaymentInternalRef());
+        } else {
+            logger.info("proceed with 3dSecure flow");
+            final Map<String, String> formParams = new HashMap<String, String>();
+            formParams.put(AdyenPaymentPluginApi.PROPERTY_PA_REQ, result.getPaRequest());
+            formParams.put(AdyenPaymentPluginApi.PROPERTY_MD, result.getMd());
+            formParams.put(AdyenPaymentPluginApi.PROPERTY_DCC_AMOUNT_VALUE, result.getDccAmount() == null ? null : String.valueOf(result.getDccAmount().getValue()));
+            formParams.put(AdyenPaymentPluginApi.PROPERTY_DCC_AMOUNT_CURRENCY, result.getDccAmount() == null ? null : result.getDccAmount().getCurrency());
+            formParams.put(AdyenPaymentPluginApi.PROPERTY_DCC_SIGNATURE, result.getDccSignature());
+            formParams.put(AdyenPaymentPluginApi.PROPERTY_ISSUER_URL, result.getIssuerUrl());
+            formParams.putAll(extractMpiAdditionalData(result));
+            if (termUrl != null) {
+                formParams.put(AdyenPaymentPluginApi.PROPERTY_TERM_URL, termUrl);
             }
 
-            logger.info("authorise Done", purchaseResult);
-            return purchaseResult;
-        } catch (final ServiceException e) {
-            logger.warn("authorise", e);
-            return handleAuthorizePaymentServiceFault(paymentData.getPaymentInternalRef(), request.getReference(), e);
-        } catch (final SOAPFaultException e) {
-            logger.warn("authorise", e);
-            return handleAuthorizePaymentSOAPFault(paymentData.getPaymentInternalRef(), request.getReference(), e);
+            purchaseResult = new PurchaseResult(paymentServiceProviderResult,
+                    result.getAuthCode(),
+                    result.getPspReference(),
+                    result.getRefusalReason(),
+                    result.getResultCode(),
+                    paymentData.getPaymentInternalRef(),
+                    result.getIssuerUrl(),
+                    formParams);
         }
+
+        logger.info("authorise Done", purchaseResult);
+        return purchaseResult;
+    }
+
+    private PurchaseResult handleTechnicalFailureAtPurchase(String callKey, PaymentData paymentData, AdyenCallResult<PaymentResult> adyenCallResult) {
+        logger.info("payment {} call failed for internalReference: {} because of: {}", callKey, paymentData.getPaymentInternalRef(), adyenCallResult);
+        return new PurchaseResult(paymentData.getPaymentInternalRef(), adyenCallResult.getResponseStatus().get());
     }
 
     public PurchaseResult authorize3DSecure(final Long billedAmount,
@@ -156,145 +141,122 @@ public class AdyenPaymentServiceProviderPort implements Closeable {
         final Card paymentInfo = paymentData.getPaymentInfo();
         final BrowserInfo info = (BrowserInfo) paymentInfoConverterManagement.getBrowserInfoFor3DSecureAuth(billedAmount, paymentData.getPaymentInfo());
         final PaymentRequest3D request = adyenRequestFactory.paymentRequest3d(paymentData.getPaymentInternalRef(),
-                                                                              paymentInfo,
-                                                                              info,
-                                                                              requestParameterMap,
-                                                                              splitSettlementData,
-                                                                              userData.getIP(),
-                                                                              userData.getEmail(),
-                                                                              userData.getCustomerId());
-        try {
-            final PaymentResult result = adyenPaymentRequestSender.authorise3D(paymentInfo.getPaymentProvider().getCountryIsoCode(), request);
+                paymentInfo,
+                info,
+                requestParameterMap,
+                splitSettlementData,
+                userData.getIP(),
+                userData.getEmail(),
+                userData.getCustomerId());
+        AdyenCallResult<PaymentResult> adyenCallResult = adyenPaymentRequestSender.authorise3D(paymentInfo.getPaymentProvider().getCountryIsoCode(), request);
 
-            final PurchaseResult purchaseResult;
-            final PaymentServiceProviderResult paymentServiceProviderResult = PaymentServiceProviderResult.getPaymentResultForId(result.getResultCode());
-            if (paymentServiceProviderResult != PaymentServiceProviderResult.REDIRECT_SHOPPER) {
-                purchaseResult = new PurchaseResult(PaymentServiceProviderResult.getPaymentResultForId(result.getResultCode()),
-                                                    result.getAuthCode(),
-                                                    result.getPspReference(),
-                                                    result.getRefusalReason(),
-                                                    result.getResultCode(),
-                                                    paymentData.getPaymentInternalRef());
-            } else {
-                final Map<String, String> formParams = new HashMap<String, String>();
-                formParams.put("PaReq", result.getPaRequest());
-                formParams.put("MD", result.getMd());
-
-                purchaseResult = new PurchaseResult(paymentServiceProviderResult,
-                                                    result.getAuthCode(),
-                                                    result.getPspReference(),
-                                                    result.getRefusalReason(),
-                                                    result.getResultCode(),
-                                                    paymentData.getPaymentInternalRef(),
-                                                    result.getIssuerUrl(),
-                                                    formParams);
-            }
-
-            logger.info("authorize3DSecure Done {}", purchaseResult);
-            return purchaseResult;
-        } catch (final ServiceException e) {
-            logger.warn("authorize3DSecure", e);
-            return handleAuthorizePaymentServiceFault(paymentData.getPaymentInternalRef(), request.getReference(), e);
-        } catch (final SOAPFaultException e) {
-            logger.warn("authorize3DSecure", e);
-            return handleAuthorizePaymentSOAPFault(paymentData.getPaymentInternalRef(), request.getReference(), e);
+        if (!adyenCallResult.receivedWellFormedResponse()) {
+            handleTechnicalFailureAtPurchase("3dSecureAuthorise", paymentData, adyenCallResult);
         }
+
+        logger.info("received adyen 3dSecure authorize response: {}", adyenCallResult);
+        PaymentResult result = adyenCallResult.getResult().get();
+        final PurchaseResult purchaseResult;
+        final PaymentServiceProviderResult paymentServiceProviderResult = PaymentServiceProviderResult.getPaymentResultForId(result.getResultCode());
+        if (paymentServiceProviderResult != PaymentServiceProviderResult.REDIRECT_SHOPPER) {
+            purchaseResult = new PurchaseResult(PaymentServiceProviderResult.getPaymentResultForId(result.getResultCode()),
+                    result.getAuthCode(),
+                    result.getPspReference(),
+                    result.getRefusalReason(),
+                    result.getResultCode(),
+                    paymentData.getPaymentInternalRef());
+        } else {
+            final Map<String, String> formParams = new HashMap<String, String>();
+            formParams.put("PaReq", result.getPaRequest());
+            formParams.put("MD", result.getMd());
+
+            purchaseResult = new PurchaseResult(paymentServiceProviderResult,
+                    result.getAuthCode(),
+                    result.getPspReference(),
+                    result.getRefusalReason(),
+                    result.getResultCode(),
+                    paymentData.getPaymentInternalRef(),
+                    result.getIssuerUrl(),
+                    formParams);
+        }
+
+        logger.info("authorize3DSecure Done {}", purchaseResult);
+        return purchaseResult;
     }
 
     public PaymentModificationResponse refund(final Long externalAmount,
                                               final PaymentProvider paymentProvider,
                                               final String pspReference,
-                                              final SplitSettlementData splitSettlementData) throws ModificationFailedException {
+                                              final SplitSettlementData splitSettlementData) {
         logger.info("refund Start for pspReference {}", pspReference);
 
-        try {
-            final ModificationRequest modificationRequest = adyenRequestFactory.paymentExecutionToAdyenModificationRequest(paymentProvider, externalAmount, pspReference, splitSettlementData);
-            final ModificationResult result = adyenPaymentRequestSender.refund(paymentProvider.getCountryIsoCode(), modificationRequest);
+        final ModificationRequest modificationRequest = adyenRequestFactory.paymentExecutionToAdyenModificationRequest(paymentProvider, externalAmount, pspReference, splitSettlementData);
+        AdyenCallResult<ModificationResult> adyenCallResult = adyenPaymentRequestSender.refund(paymentProvider.getCountryIsoCode(), modificationRequest);
 
-            logger.debug("refund for pspReference: {}, got new pspReference: {} and response {}", pspReference, result.getPspReference(), result.getResponse());
-
-            final PaymentModificationResponse paymentModificationResponse = new PaymentModificationResponse(result.getResponse(),
-                                                                                                            result.getPspReference(),
-                                                                                                            entriesToMap(result.getAdditionalData()));
-            logger.info("refund End: {}", paymentModificationResponse);
-            return paymentModificationResponse;
-        } catch (final ServiceException e) {
-            logger.warn("refund", e);
-            throw new ModificationFailedException(e);
-        } catch (final SOAPFaultException e) {
-            logger.warn("refund", e);
-            throw new ModificationFailedException(e);
+        if (!adyenCallResult.receivedWellFormedResponse()) {
+            return handleTechnicalErrorAtModificationRequest("refund", pspReference, adyenCallResult);
         }
+
+        ModificationResult result = adyenCallResult.getResult().get();
+        logger.debug("refund for pspReference: {}, got new pspReference: {} and response {}", pspReference, result.getPspReference(), result.getResponse());
+
+        final PaymentModificationResponse paymentModificationResponse = new PaymentModificationResponse(result.getResponse(),
+                result.getPspReference(),
+                entriesToMap(result.getAdditionalData()));
+        logger.info("refund End: {}", paymentModificationResponse);
+        return paymentModificationResponse;
+    }
+
+    private PaymentModificationResponse handleTechnicalErrorAtModificationRequest(String callKey, String pspReference, AdyenCallResult<ModificationResult> adyenCallResult) {
+        logger.info("payment {} call failed for pspRef: {} because of: {}", callKey, pspReference, adyenCallResult);
+        return new PaymentModificationResponse(pspReference, adyenCallResult.getResponseStatus().get());
     }
 
     public PaymentModificationResponse cancel(final PaymentProvider paymentProvider,
                                               final String pspReference,
-                                              final SplitSettlementData splitSettlementData) throws ModificationFailedException {
+                                              final SplitSettlementData splitSettlementData) {
         logger.info("cancel Start for pspReference {}", pspReference);
 
-        try {
-            final ModificationRequest modificationRequest = adyenRequestFactory.paymentExecutionToAdyenModificationRequest(paymentProvider, pspReference, splitSettlementData);
-            final ModificationResult result = adyenPaymentRequestSender.cancel(paymentProvider.getCountryIsoCode(), modificationRequest);
+        final ModificationRequest modificationRequest = adyenRequestFactory.paymentExecutionToAdyenModificationRequest(paymentProvider, pspReference, splitSettlementData);
+        AdyenCallResult<ModificationResult> adyenCallResult = adyenPaymentRequestSender.cancel(paymentProvider.getCountryIsoCode(), modificationRequest);
 
-            logger.debug("cancel for pspReference: {}, got new pspReference: {} and response {}", pspReference, result.getPspReference(), result.getResponse());
-
-            final PaymentModificationResponse response = new PaymentModificationResponse(result.getResponse(),
-                                                                                         result.getPspReference(),
-                                                                                         entriesToMap(result.getAdditionalData()));
-            logger.info("cancel End", response);
-            return response;
-        } catch (final ServiceException e) {
-            logger.warn("cancel", e);
-            throw new ModificationFailedException(e);
-        } catch (final SOAPFaultException e) {
-            logger.warn("cancel", e);
-            throw new ModificationFailedException(e);
+        if (!adyenCallResult.receivedWellFormedResponse()) {
+            return handleTechnicalErrorAtModificationRequest("refund", pspReference, adyenCallResult);
         }
+
+        ModificationResult result = adyenCallResult.getResult().get();
+        logger.debug("cancel for pspReference: {}, got new pspReference: {} and response {}", pspReference, result.getPspReference(), result.getResponse());
+
+        final PaymentModificationResponse response = new PaymentModificationResponse(result.getResponse(),
+                result.getPspReference(),
+                entriesToMap(result.getAdditionalData()));
+        logger.info("cancel End", response);
+        return response;
     }
 
     public PaymentModificationResponse capture(final Long amount,
                                                final PaymentProvider paymentProvider,
                                                final String pspReference,
-                                               final SplitSettlementData splitSettlementData) throws ModificationFailedException {
+                                               final SplitSettlementData splitSettlementData) {
         logger.info("capture Start for pspReference {}", pspReference);
 
-        try {
-            final ModificationRequest modificationRequest = adyenRequestFactory.paymentExecutionToAdyenModificationRequest(paymentProvider, amount, pspReference, splitSettlementData);
-            final ModificationResult result = adyenPaymentRequestSender.capture(paymentProvider.getCountryIsoCode(), modificationRequest);
+        final ModificationRequest modificationRequest = adyenRequestFactory.paymentExecutionToAdyenModificationRequest(paymentProvider, amount, pspReference, splitSettlementData);
+        AdyenCallResult<ModificationResult> adyenCallResult = adyenPaymentRequestSender.capture(paymentProvider.getCountryIsoCode(), modificationRequest);
 
-            logger.debug("capture for pspReference: {}, got new pspReference: {} and response {}", pspReference, result.getPspReference(), result.getResponse());
-
-            final PaymentModificationResponse response = new PaymentModificationResponse(result.getResponse(),
-                                                                                         result.getPspReference(),
-                                                                                         entriesToMap(result.getAdditionalData()));
-            logger.info("capture End", response);
-            return response;
-        } catch (final ServiceException e) {
-            logger.warn("capture", e);
-            throw new ModificationFailedException(e);
-        } catch (final SOAPFaultException e) {
-            logger.warn("capture", e);
-            throw new ModificationFailedException(e);
-        }
-    }
-
-    private PurchaseResult handleAuthorizePaymentServiceFault(final String internalRef, final String reference, final ServiceException se) {
-        logger.error("payment failed for internalReference: " + internalRef, se);
-        return new PurchaseResult(PaymentServiceProviderResult.ERROR, se.getMessage(), reference, AdyenPaymentExceptionParser.parsePaymentException(se.getMessage()), internalRef);
-    }
-
-    private PurchaseResult handleAuthorizePaymentSOAPFault(final String paymentInternalRef, final String reference, final SOAPFaultException e) {
-        final PaymentServiceProviderResult pspResult;
-        if (e.getMessage().contains(REFUSED_FAILURE)) {
-            pspResult = PaymentServiceProviderResult.REFUSED;
-            logger.info("Payment authentication failed for internalReference: " + paymentInternalRef + ", error message: " + e.getMessage());
-        } else {
-            pspResult = PaymentServiceProviderResult.ERROR;
-            logger.warn("Payment authentication failed for internalReference: " + paymentInternalRef + ", error message: " + e.getMessage());
+        if (!adyenCallResult.receivedWellFormedResponse()) {
+            return handleTechnicalErrorAtModificationRequest("capture", pspReference, adyenCallResult);
         }
 
-        return new PurchaseResult(pspResult, e.getMessage(), reference, AdyenPaymentExceptionParser.parsePaymentException(e.getMessage()), paymentInternalRef);
+        ModificationResult result = adyenCallResult.getResult().get();
+        logger.debug("capture for pspReference: {}, got new pspReference: {} and response {}", pspReference, result.getPspReference(), result.getResponse());
+
+        final PaymentModificationResponse response = new PaymentModificationResponse(result.getResponse(),
+                result.getPspReference(),
+                entriesToMap(result.getAdditionalData()));
+        logger.info("capture End", response);
+        return response;
     }
+
 
     /**
      * Extract MPI specific form data from the result's additional data.

--- a/src/test/java/org/killbill/billing/plugin/adyen/AdyenPluginMockBuilder.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/AdyenPluginMockBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 Groupon, Inc
+ * Copyright 2015 Groupon, Inc
  *
  * Groupon licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -13,12 +13,13 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package org.killbill.billing.plugin.adyen;
 
+
 import org.killbill.billing.account.api.Account;
-import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.payment.api.Payment;
 import org.killbill.billing.plugin.TestUtils;
+import org.killbill.billing.plugin.adyen.api.AdyenPaymentPluginApi;
 import org.killbill.billing.plugin.adyen.client.AdyenConfigProperties;
 import org.killbill.billing.plugin.adyen.client.AdyenPaymentPortRegistry;
 import org.killbill.billing.plugin.adyen.client.PaymentPortRegistry;
@@ -35,45 +36,66 @@ import org.killbill.billing.plugin.adyen.client.payment.service.Signer;
 import org.killbill.billing.plugin.adyen.core.AdyenActivator;
 import org.killbill.billing.plugin.adyen.core.AdyenConfigurationHandler;
 import org.killbill.billing.plugin.adyen.core.AdyenHostedPaymentPageConfigurationHandler;
+import org.killbill.billing.plugin.adyen.dao.AdyenDao;
+import org.killbill.clock.Clock;
+import org.killbill.clock.DefaultClock;
+import org.killbill.killbill.osgi.libs.killbill.OSGIConfigPropertiesService;
 import org.killbill.killbill.osgi.libs.killbill.OSGIKillbillAPI;
 import org.killbill.killbill.osgi.libs.killbill.OSGIKillbillLogService;
-import org.testng.annotations.BeforeClass;
 
 import java.io.IOException;
+import java.sql.SQLException;
 import java.util.Properties;
 
-public abstract class TestRemoteBase {
+import static org.mockito.Mockito.mock;
 
-    // Simulate payments using a credit card in Germany (requires credentials for a German merchant account)
-    public static final Currency DEFAULT_CURRENCY = Currency.EUR;
-    public static final String DEFAULT_COUNTRY = "DE";
-    // Magic details at https://www.adyen.com/home/support/knowledgebase/implementation-articles.html
-    // Note: make sure to use the Amex one, as Visa/MC is not always configured by default
-    public static final String CC_NUMBER = "370000000000002";
-    public static final int CC_EXPIRATION_MONTH = 8;
-    public static final int CC_EXPIRATION_YEAR = 2018;
-    public static final String CC_VERIFICATION_VALUE = "7373";
-    public static final String CC_TYPE = "amex";
-    public static final String DD_IBAN = "DE87123456781234567890";
-    public static final String DD_BIC = "TESTDE01XXX";
-    public static final String DD_HOLDER_NAME = "A. Schneider";
-    public static final String DD_TYPE = "sepadirectdebit";
-    public static final String ELV_ACCOUNT_NUMBER = "1234567890";
-    public static final String ELV_BLZ = "12345678";
-    public static final String ELV_HOLDER_NAME = "Bill Killson";
-    public static final String ELV_TYPE = "elv";
+/**
+ * First version of a test builder with a fluent api.
+ * Goal is to have a more configurable test setup.
+ * <p/>
+ * TODO remove parts which are redundant with TestRemoteBase
+ */
+public class AdyenPluginMockBuilder {
+
     // To run these tests, you need a properties file in the classpath (e.g. src/test/resources/adyen.properties)
     // See README.md for details on the required properties
     private static final String PROPERTIES_FILE_NAME = "adyen.properties";
-    protected AdyenConfigProperties adyenConfigProperties;
-    protected AdyenConfigurationHandler adyenConfigurationHandler;
-    protected AdyenHostedPaymentPageConfigurationHandler adyenHostedPaymentPageConfigurationHandler;
-    protected AdyenPaymentServiceProviderPort adyenPaymentServiceProviderPort;
-    protected AdyenPaymentServiceProviderHostedPaymentPagePort adyenPaymentServiceProviderHostedPaymentPagePort;
+    private final Properties adyenProperties;
+    private Account account;
+    private Payment payment;
+    private AdyenDao dao;
 
-    @BeforeClass(groups = "slow")
-    public void setUpBeforeClass() throws Exception {
-        adyenConfigProperties = getAdyenConfigProperties();
+    private AdyenPluginMockBuilder() throws IOException, SQLException {
+        adyenProperties = getDefaultAdyenConfigProperties();
+        dao = mock(AdyenDao.class);
+
+    }
+
+    public static AdyenPluginMockBuilder newPlugin() throws Exception {
+        return new AdyenPluginMockBuilder();
+    }
+
+    private static Properties getDefaultAdyenConfigProperties() throws IOException {
+        return TestUtils.loadProperties(PROPERTIES_FILE_NAME);
+    }
+
+    public AdyenPluginMockBuilder withAdyenProperty(String key, String value) {
+        adyenProperties.setProperty(key, value);
+        return this;
+    }
+
+    public AdyenPluginMockBuilder withAccount(Account account) {
+        this.account = account;
+        return this;
+    }
+
+    public AdyenPluginMockBuilder withPayment(Payment payment) {
+        this.payment = payment;
+        return this;
+    }
+
+    public AdyenPaymentPluginApi build() throws Exception {
+        AdyenConfigProperties adyenConfigProperties = new AdyenConfigProperties(adyenProperties);
 
         final PaymentInfoConverterManagement paymentInfoConverterManagement = new PaymentInfoConverterService();
 
@@ -86,22 +108,29 @@ public abstract class TestRemoteBase {
         final PaymentPortRegistry adyenPaymentPortRegistry = new AdyenPaymentPortRegistry(adyenConfigProperties, loggingInInterceptor, loggingOutInterceptor, httpHeaderInterceptor);
         final AdyenPaymentRequestSender adyenPaymentRequestSender = new AdyenPaymentRequestSender(adyenPaymentPortRegistry);
 
-        adyenPaymentServiceProviderPort = new AdyenPaymentServiceProviderPort(paymentInfoConverterManagement, adyenRequestFactory, adyenPaymentRequestSender);
-        adyenPaymentServiceProviderHostedPaymentPagePort = new AdyenPaymentServiceProviderHostedPaymentPagePort(adyenConfigProperties, adyenRequestFactory);
+        AdyenPaymentServiceProviderPort adyenPaymentServiceProviderPort = new AdyenPaymentServiceProviderPort(paymentInfoConverterManagement, adyenRequestFactory, adyenPaymentRequestSender);
+        AdyenPaymentServiceProviderHostedPaymentPagePort adyenPaymentServiceProviderHostedPaymentPagePort = new AdyenPaymentServiceProviderHostedPaymentPagePort(adyenConfigProperties, adyenRequestFactory);
 
-        final Account account = TestUtils.buildAccount(Currency.BTC, "US");
         final OSGIKillbillAPI killbillAPI = TestUtils.buildOSGIKillbillAPI(account, TestUtils.buildPayment(account.getId(), account.getPaymentMethodId(), account.getCurrency()), null);
         final OSGIKillbillLogService logService = TestUtils.buildLogService();
 
-        adyenConfigurationHandler = new AdyenConfigurationHandler(AdyenActivator.PLUGIN_NAME, killbillAPI, logService);
+        AdyenConfigurationHandler adyenConfigurationHandler = new AdyenConfigurationHandler(AdyenActivator.PLUGIN_NAME, killbillAPI, logService);
         adyenConfigurationHandler.setDefaultConfigurable(adyenPaymentServiceProviderPort);
 
-        adyenHostedPaymentPageConfigurationHandler = new AdyenHostedPaymentPageConfigurationHandler(AdyenActivator.PLUGIN_NAME, killbillAPI, logService);
+        AdyenHostedPaymentPageConfigurationHandler adyenHostedPaymentPageConfigurationHandler = new AdyenHostedPaymentPageConfigurationHandler(AdyenActivator.PLUGIN_NAME, killbillAPI, logService);
         adyenHostedPaymentPageConfigurationHandler.setDefaultConfigurable(adyenPaymentServiceProviderHostedPaymentPagePort);
+
+        final Clock clock = new DefaultClock();
+
+        final OSGIKillbillAPI killbillApi = TestUtils.buildOSGIKillbillAPI(account, payment, null);
+
+        final OSGIConfigPropertiesService configPropertiesService = mock(OSGIConfigPropertiesService.class);
+
+        return new AdyenPaymentPluginApi(adyenConfigurationHandler, adyenHostedPaymentPageConfigurationHandler, killbillApi, configPropertiesService, logService, clock, dao);
     }
 
-    private AdyenConfigProperties getAdyenConfigProperties() throws IOException {
-        final Properties properties = TestUtils.loadProperties(PROPERTIES_FILE_NAME);
-        return new AdyenConfigProperties(properties);
+    public AdyenPluginMockBuilder withDatabaseAccess(AdyenDao dao) {
+        this.dao = dao;
+        return this;
     }
 }

--- a/src/test/java/org/killbill/billing/plugin/adyen/EmbeddedDbHelper.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/EmbeddedDbHelper.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 Groupon, Inc
+ *
+ * Groupon licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.killbill.billing.plugin.adyen;
+
+import org.killbill.billing.plugin.TestUtils;
+import org.killbill.billing.plugin.adyen.dao.AdyenDao;
+import org.killbill.commons.embeddeddb.mysql.MySQLEmbeddedDB;
+
+public class EmbeddedDbHelper {
+
+    private static final String DDL_FILE_NAME = "ddl.sql";
+
+    private static final EmbeddedDbHelper INSTANCE = new EmbeddedDbHelper();
+    private MySQLEmbeddedDB embeddedDB;
+
+    public static EmbeddedDbHelper instance() {
+        return INSTANCE;
+    }
+
+    public AdyenDao startDb() throws Exception {
+
+        embeddedDB = new MySQLEmbeddedDB();
+        embeddedDB.initialize();
+        embeddedDB.start();
+
+        final String ddl = TestUtils.toString(DDL_FILE_NAME);
+        embeddedDB.executeScript(ddl);
+        embeddedDB.refreshTableNames();
+
+        return new AdyenDao(embeddedDB.getDataSource());
+    }
+
+    public void resetDB() throws Exception {
+        embeddedDB.cleanupAllTables();
+    }
+
+    public void stopDB() throws Exception {
+        embeddedDB.stop();
+    }
+}

--- a/src/test/java/org/killbill/billing/plugin/adyen/TestWithEmbeddedDBBase.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/TestWithEmbeddedDBBase.java
@@ -16,9 +16,7 @@
 
 package org.killbill.billing.plugin.adyen;
 
-import org.killbill.billing.plugin.TestUtils;
 import org.killbill.billing.plugin.adyen.dao.AdyenDao;
-import org.killbill.commons.embeddeddb.mysql.MySQLEmbeddedDB;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -27,33 +25,22 @@ import org.testng.annotations.BeforeMethod;
 // (see TestAdyenDao), but it's a quick workaround for unsupported multiple inheritance
 public abstract class TestWithEmbeddedDBBase extends TestRemoteBase {
 
-    private static final String DDL_FILE_NAME = "ddl.sql";
-
-    protected MySQLEmbeddedDB embeddedDB;
     protected AdyenDao dao;
 
     @BeforeClass(groups = "slow")
     public void setUpBeforeClass() throws Exception {
         super.setUpBeforeClass();
 
-        embeddedDB = new MySQLEmbeddedDB();
-        embeddedDB.initialize();
-        embeddedDB.start();
-
-        final String ddl = TestUtils.toString(DDL_FILE_NAME);
-        embeddedDB.executeScript(ddl);
-        embeddedDB.refreshTableNames();
-
-        dao = new AdyenDao(embeddedDB.getDataSource());
+        dao = EmbeddedDbHelper.instance().startDb();
     }
 
     @BeforeMethod(groups = "slow")
     public void setUpBeforeMethod() throws Exception {
-        embeddedDB.cleanupAllTables();
+        EmbeddedDbHelper.instance().resetDB();
     }
 
     @AfterClass(groups = "slow")
     public void tearDownAfterClass() throws Exception {
-        embeddedDB.stop();
+        EmbeddedDbHelper.instance().stopDB();
     }
 }

--- a/src/test/java/org/killbill/billing/plugin/adyen/api/TestAdyenPaymentPluginHttpErrors.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/api/TestAdyenPaymentPluginHttpErrors.java
@@ -1,0 +1,405 @@
+/*
+ * Copyright 2015 Groupon, Inc
+ *
+ * Groupon licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.killbill.billing.plugin.adyen.api;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.http.Fault;
+import com.google.common.collect.ImmutableMap;
+import org.joda.time.DateTime;
+import org.killbill.billing.account.api.Account;
+import org.killbill.billing.catalog.api.Currency;
+import org.killbill.billing.payment.api.Payment;
+import org.killbill.billing.payment.api.PaymentTransaction;
+import org.killbill.billing.payment.api.PluginProperty;
+import org.killbill.billing.payment.api.TransactionType;
+import org.killbill.billing.payment.plugin.api.PaymentPluginApiException;
+import org.killbill.billing.payment.plugin.api.PaymentPluginStatus;
+import org.killbill.billing.payment.plugin.api.PaymentTransactionInfoPlugin;
+import org.killbill.billing.plugin.TestUtils;
+import org.killbill.billing.plugin.adyen.AdyenPluginMockBuilder;
+import org.killbill.billing.plugin.adyen.EmbeddedDbHelper;
+import org.killbill.billing.plugin.adyen.dao.AdyenDao;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.killbill.billing.plugin.TestUtils.toProperties;
+import static org.killbill.billing.plugin.adyen.TestRemoteBase.*;
+import static org.killbill.billing.plugin.adyen.api.TestAdyenPaymentPluginHttpErrors.WireMockHelper.doWithWireMock;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Checks if the plugin could handle technical communication errors (strange responses, read/connect timeouts etc...) and map them to the correct PaymentPluginStatus.
+ * <p/>
+ * Wiremock is used to create failure scenarios (toxiproxy will be used in the ruby ITs).
+ */
+public class TestAdyenPaymentPluginHttpErrors {
+
+    //TODO was not able to provoke a connection timeout (addRequestProcessingDelay() had no effect: http://wiremock.org/simulating-faults.html)
+
+    private AdyenDao dao;
+
+    @BeforeClass(groups = "slow")
+    public void setUpBeforeClass() throws Exception {
+
+        dao = EmbeddedDbHelper.instance().startDb();
+    }
+
+    @BeforeMethod(groups = "slow")
+    public void setUpBeforeMethod() throws Exception {
+        EmbeddedDbHelper.instance().resetDB();
+    }
+
+    @AfterClass(groups = "slow")
+    public void tearDownAfterClass() throws Exception {
+        EmbeddedDbHelper.instance().stopDB();
+    }
+
+    @Test(groups = "slow")
+    public void testAuthorizeAdyenNotReachable() throws Exception {
+
+        String unReachableUri = "http://nothing-here.to";
+
+        final Account account = defaultAccount();
+        Payment payment = killBillPayment(account);
+        AdyenCallContext callContext = newCallContext();
+
+        AdyenPaymentPluginApi pluginApi = AdyenPluginMockBuilder.newPlugin()
+                .withAdyenProperty("org.killbill.billing.plugin.adyen.paymentUrl", unReachableUri)
+                .withAccount(account)
+                .withPayment(payment)
+                .build();
+
+        final PaymentTransactionInfoPlugin result = authorizeCall(account, payment, callContext, pluginApi, creditCardPaymentProperties());
+
+        assertEquals(result.getStatus(), PaymentPluginStatus.CANCELED);
+    }
+
+
+    @Test(groups = "slow")
+    public void testAuthorizeWithInvalidValues() throws Exception {
+
+        final Account account = defaultAccount();
+        Payment payment = killBillPayment(account);
+        AdyenCallContext callContext = newCallContext();
+
+        AdyenPaymentPluginApi pluginApi = AdyenPluginMockBuilder.newPlugin()
+                .withAccount(account)
+                .withPayment(payment)
+                .build();
+
+        final PaymentTransactionInfoPlugin result = authorizeCall(account, payment, callContext, pluginApi, invalidCreditCardData());
+
+        assertEquals(result.getStatus(), PaymentPluginStatus.ERROR);
+    }
+
+    @Test(groups = "slow")
+    public void testAuthorizeAdyenReadTimeout() throws Exception {
+
+        final Account account = defaultAccount();
+        final Payment payment = killBillPayment(account);
+        final AdyenCallContext callContext = newCallContext();
+
+        final AdyenPaymentPluginApi pluginApi = AdyenPluginMockBuilder.newPlugin()
+                .withAdyenProperty("org.killbill.billing.plugin.adyen.paymentUrl", "http://localhost:8089/adyen")
+                .withAdyenProperty("org.killbill.billing.plugin.adyen.paymentReadTimeout", "100")
+                .withAccount(account)
+                .withPayment(payment)
+                .build();
+
+        PaymentTransactionInfoPlugin result = doWithWireMock(new WithWireMock<PaymentTransactionInfoPlugin>() {
+            @Override
+            public PaymentTransactionInfoPlugin execute(WireMockServer server) throws PaymentPluginApiException {
+
+                stubFor(post(urlEqualTo("/adyen")).willReturn(
+                        aResponse()
+                                .withStatus(200)
+                                .withFixedDelay(400)));
+
+                return authorizeCall(account, payment, callContext, pluginApi, creditCardPaymentProperties());
+            }
+        });
+
+        assertEquals(result.getStatus(), PaymentPluginStatus.UNDEFINED);
+    }
+
+    @Test(groups = "slow")
+    public void testAuthorizeAdyenBadResponse() throws Exception {
+
+        final Account account = defaultAccount();
+        final Payment payment = killBillPayment(account);
+        final AdyenCallContext callContext = newCallContext();
+
+        final AdyenPaymentPluginApi pluginApi = AdyenPluginMockBuilder.newPlugin()
+                .withAdyenProperty("org.killbill.billing.plugin.adyen.paymentUrl", "http://localhost:8089/adyen")
+                .withAccount(account)
+                .withPayment(payment)
+                .build();
+
+        PaymentTransactionInfoPlugin result = doWithWireMock(new WithWireMock<PaymentTransactionInfoPlugin>() {
+            @Override
+            public PaymentTransactionInfoPlugin execute(WireMockServer server) throws Exception {
+                stubFor(post(urlEqualTo("/adyen")).willReturn(
+                        aResponse()
+                                .withFault(Fault.RANDOM_DATA_THEN_CLOSE)
+                                .withStatus(200)));
+
+
+                return authorizeCall(account, payment, callContext, pluginApi, creditCardPaymentProperties());
+            }
+        });
+
+        assertEquals(result.getStatus(), PaymentPluginStatus.UNDEFINED);
+    }
+
+    @Test(groups = "slow")
+    public void testRefundAdyenBadResponse() throws Exception {
+
+        final Account account = defaultAccount();
+        final Payment payment = killBillPayment(account);
+        final AdyenCallContext callContext = newCallContext();
+
+        final AdyenPaymentPluginApi authorizeApi = AdyenPluginMockBuilder.newPlugin()
+                .withAccount(account)
+                .withPayment(payment)
+                .withDatabaseAccess(dao)
+                .build();
+
+        authorizeCall(account, payment, callContext, authorizeApi, creditCardPaymentProperties());
+
+        final AdyenPaymentPluginApi refundApi = AdyenPluginMockBuilder.newPlugin()
+                .withAdyenProperty("org.killbill.billing.plugin.adyen.paymentUrl", "http://localhost:8089/adyen")
+                .withAccount(account)
+                .withPayment(payment)
+                .withDatabaseAccess(dao)
+                .build();
+
+        PaymentTransactionInfoPlugin result = doWithWireMock(new WithWireMock<PaymentTransactionInfoPlugin>() {
+            @Override
+            public PaymentTransactionInfoPlugin execute(WireMockServer server) throws Exception {
+                stubFor(post(urlEqualTo("/adyen")).willReturn(
+                        aResponse()
+                                .withFault(Fault.RANDOM_DATA_THEN_CLOSE)
+                                .withStatus(200)));
+
+                final PaymentTransaction refundTransaction = TestUtils.buildPaymentTransaction(payment, TransactionType.REFUND, Currency.EUR);
+
+                return refundApi.refundPayment(account.getId(),
+                        payment.getId(),
+                        refundTransaction.getId(),
+                        account.getPaymentMethodId(),
+                        refundTransaction.getAmount(),
+                        refundTransaction.getCurrency(),
+                        creditCardPaymentProperties(),
+                        callContext);
+            }
+        });
+
+        assertEquals(result.getStatus(), PaymentPluginStatus.UNDEFINED);
+    }
+
+    @Test(groups = "slow")
+    public void testAuthorizeAdyenEmptyResponse() throws Exception {
+
+        final Account account = defaultAccount();
+        final Payment payment = killBillPayment(account);
+        final AdyenCallContext callContext = newCallContext();
+
+
+        final AdyenPaymentPluginApi pluginApi = AdyenPluginMockBuilder.newPlugin()
+                .withAdyenProperty("org.killbill.billing.plugin.adyen.paymentUrl", "http://localhost:8089/adyen")
+                .withAccount(account)
+                .withPayment(payment)
+                .build();
+
+        PaymentTransactionInfoPlugin result = doWithWireMock(new WithWireMock<PaymentTransactionInfoPlugin>() {
+            @Override
+            public PaymentTransactionInfoPlugin execute(WireMockServer server) throws Exception {
+                stubFor(post(urlEqualTo("/adyen")).willReturn(
+                        aResponse()
+                                .withFault(Fault.EMPTY_RESPONSE)
+                                .withStatus(200)));
+
+                return authorizeCall(account, payment, callContext, pluginApi, creditCardPaymentProperties());
+            }
+        });
+
+        assertEquals(result.getStatus(), PaymentPluginStatus.UNDEFINED);
+    }
+
+
+    @Test(groups = "slow")
+    public void testAuthorizeAdyenMalformedResponseChunk() throws Exception {
+
+        final Account account = defaultAccount();
+        final Payment payment = killBillPayment(account);
+        final AdyenCallContext callContext = newCallContext();
+
+        final AdyenPaymentPluginApi pluginApi = AdyenPluginMockBuilder.newPlugin()
+                .withAdyenProperty("org.killbill.billing.plugin.adyen.paymentUrl", "http://localhost:8089/adyen")
+                .withAccount(account)
+                .withPayment(payment)
+                .build();
+
+        PaymentTransactionInfoPlugin result = doWithWireMock(new WithWireMock<PaymentTransactionInfoPlugin>() {
+            @Override
+            public PaymentTransactionInfoPlugin execute(WireMockServer server) throws Exception {
+                stubFor(post(urlEqualTo("/adyen")).willReturn(
+                        aResponse()
+                                .withFault(Fault.MALFORMED_RESPONSE_CHUNK)
+                                .withStatus(200)));
+
+                return authorizeCall(account, payment, callContext, pluginApi, creditCardPaymentProperties());
+            }
+        });
+
+        assertEquals(result.getStatus(), PaymentPluginStatus.UNDEFINED);
+    }
+
+
+    @Test(groups = "slow")
+    public void testAuthorizeAdyenRespondWith404() throws Exception {
+
+        final Account account = defaultAccount();
+        final Payment payment = killBillPayment(account);
+        final AdyenCallContext callContext = newCallContext();
+
+        final AdyenPaymentPluginApi pluginApi = AdyenPluginMockBuilder.newPlugin()
+                .withAdyenProperty("org.killbill.billing.plugin.adyen.paymentUrl", "http://localhost:8089/adyen")
+                .withAccount(account)
+                .withPayment(payment)
+                .build();
+
+        PaymentTransactionInfoPlugin result = doWithWireMock(new WithWireMock<PaymentTransactionInfoPlugin>() {
+            @Override
+            public PaymentTransactionInfoPlugin execute(WireMockServer server) throws Exception {
+                stubFor(post(urlEqualTo("/adyen")).willReturn(
+                        aResponse()
+                                .withStatus(404)));
+
+
+                return authorizeCall(account, payment, callContext, pluginApi, creditCardPaymentProperties());
+            }
+        });
+
+        assertEquals(result.getStatus(), PaymentPluginStatus.UNDEFINED);
+    }
+
+    @Test(groups = "slow")
+    public void testAuthorizeAdyenRespondWith301() throws Exception {
+
+        final Account account = defaultAccount();
+        final Payment payment = killBillPayment(account);
+        final AdyenCallContext callContext = newCallContext();
+
+        final AdyenPaymentPluginApi pluginApi = AdyenPluginMockBuilder.newPlugin()
+                .withAdyenProperty("org.killbill.billing.plugin.adyen.paymentUrl", "http://localhost:8089/adyen")
+                .withAccount(account)
+                .withPayment(payment)
+                .build();
+
+        PaymentTransactionInfoPlugin result = doWithWireMock(new WithWireMock<PaymentTransactionInfoPlugin>() {
+            @Override
+            public PaymentTransactionInfoPlugin execute(WireMockServer server) throws Exception {
+                stubFor(post(urlEqualTo("/adyen")).willReturn(
+                        aResponse()
+                                .withStatus(301)));
+
+                return authorizeCall(account, payment, callContext, pluginApi, creditCardPaymentProperties());
+
+            }
+        });
+
+        assertEquals(result.getStatus(), PaymentPluginStatus.UNDEFINED);
+    }
+
+    private List<PluginProperty> invalidCreditCardData() {
+        HashMap<String, String> invalidCreditCardData = new HashMap<String, String>(validCreditCardData());
+        invalidCreditCardData.put(AdyenPaymentPluginApi.PROPERTY_CC_EXPIRATION_MONTH, String.valueOf("123"));
+        return toProperties(invalidCreditCardData);
+    }
+
+    private AdyenCallContext newCallContext() {
+        return new AdyenCallContext(DateTime.now(), UUID.randomUUID());
+    }
+
+
+    private Payment killBillPayment(Account account) {
+        return TestUtils.buildPayment(account.getId(), account.getPaymentMethodId(), account.getCurrency());
+    }
+
+    private List<PluginProperty> creditCardPaymentProperties() {
+        return toProperties(validCreditCardData());
+    }
+
+    private ImmutableMap<String, String> validCreditCardData() {
+        return ImmutableMap.<String, String>builder()
+                .put(AdyenPaymentPluginApi.PROPERTY_CC_TYPE, CC_TYPE)
+                .put(AdyenPaymentPluginApi.PROPERTY_CC_LAST_NAME, "Dupont")
+                .put(AdyenPaymentPluginApi.PROPERTY_CC_NUMBER, CC_NUMBER)
+                .put(AdyenPaymentPluginApi.PROPERTY_CC_EXPIRATION_MONTH, String.valueOf(CC_EXPIRATION_MONTH))
+                .put(AdyenPaymentPluginApi.PROPERTY_CC_EXPIRATION_YEAR, String.valueOf(CC_EXPIRATION_YEAR))
+                .put(AdyenPaymentPluginApi.PROPERTY_CC_VERIFICATION_VALUE, CC_VERIFICATION_VALUE).build();
+    }
+
+    private Account defaultAccount() {
+        return TestUtils.buildAccount(DEFAULT_CURRENCY, DEFAULT_COUNTRY);
+    }
+
+    private PaymentTransactionInfoPlugin authorizeCall(Account account, Payment payment, AdyenCallContext callContext, AdyenPaymentPluginApi pluginApi, List<PluginProperty> pluginProperties) throws PaymentPluginApiException {
+        final PaymentTransaction authorizationTransaction = TestUtils.buildPaymentTransaction(payment, TransactionType.AUTHORIZE, Currency.EUR);
+
+        return pluginApi.authorizePayment(account.getId(),
+                payment.getId(),
+                authorizationTransaction.getId(),
+                account.getPaymentMethodId(),
+                authorizationTransaction.getAmount(),
+                authorizationTransaction.getCurrency(),
+                pluginProperties,
+                callContext);
+    }
+
+    private interface WithWireMock<T> {
+        T execute(WireMockServer server) throws Exception;
+    }
+
+    static class WireMockHelper {
+
+        private static final int WIRE_MOCK_PORT = 8089;
+
+        public static <T> T doWithWireMock(WithWireMock<T> command) throws Exception {
+            WireMockServer wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().port(8089));
+            wireMockServer.start();
+            WireMock.configureFor("localhost", WIRE_MOCK_PORT);
+            try {
+                return command.execute(wireMockServer);
+            } finally {
+                wireMockServer.shutdown();
+                while (wireMockServer.isRunning()) {
+                    Thread.sleep(1);
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/org/killbill/billing/plugin/adyen/client/payment/service/TestAdyenPaymentRequestSender.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/client/payment/service/TestAdyenPaymentRequestSender.java
@@ -16,8 +16,6 @@
 
 package org.killbill.billing.plugin.adyen.client.payment.service;
 
-import javax.xml.ws.WebServiceException;
-
 import org.killbill.adyen.payment.ModificationRequest;
 import org.killbill.adyen.payment.ModificationResult;
 import org.killbill.adyen.payment.PaymentPortType;
@@ -29,6 +27,8 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import javax.xml.ws.WebServiceException;
 
 // Note: retries have been disabled for now
 public class TestAdyenPaymentRequestSender {
@@ -42,7 +42,7 @@ public class TestAdyenPaymentRequestSender {
 
         final ModificationRequest modificationRequest = new ModificationRequest();
         Mockito.when(paymentPort.cancel(modificationRequest)).thenAnswer(new ThrowExceptionForNTimesBeforeReturningResult(numberOfAttempts - 1, new WebServiceException()));
-        final ModificationResult result = adyenPaymentRequestSender.cancel("any", modificationRequest);
+        AdyenCallResult<ModificationResult> result = adyenPaymentRequestSender.cancel("any", modificationRequest);
 
         Mockito.verify(paymentPort, Mockito.atLeast(numberOfAttempts)).cancel(modificationRequest);
         Assert.assertNotNull(result);
@@ -57,7 +57,7 @@ public class TestAdyenPaymentRequestSender {
 
         final ModificationRequest modificationRequest = new ModificationRequest();
         Mockito.when(paymentPort.cancel(modificationRequest)).thenAnswer(new ThrowExceptionForNTimesBeforeReturningResult(numberOfAttempts - 1, new WebServiceException()));
-        final ModificationResult result = adyenPaymentRequestSender.cancel("any", modificationRequest);
+        AdyenCallResult<ModificationResult> result = adyenPaymentRequestSender.cancel("any", modificationRequest);
 
         Mockito.verify(paymentPort, Mockito.atLeastOnce()).cancel(modificationRequest);
         Assert.assertNotNull(result);
@@ -84,7 +84,7 @@ public class TestAdyenPaymentRequestSender {
 
         final ModificationRequest modificationRequest = new ModificationRequest();
         Mockito.when(paymentPort.cancelOrRefund(modificationRequest)).thenAnswer(new ThrowExceptionForNTimesBeforeReturningResult(numberOfAttempts - 1, new WebServiceException()));
-        final ModificationResult result = adyenPaymentRequestSender.cancelOrRefund("any", modificationRequest);
+        AdyenCallResult<ModificationResult> result = adyenPaymentRequestSender.cancelOrRefund("any", modificationRequest);
 
         Mockito.verify(paymentPort, Mockito.atLeast(numberOfAttempts)).cancelOrRefund(modificationRequest);
         Assert.assertNotNull(result);
@@ -99,7 +99,7 @@ public class TestAdyenPaymentRequestSender {
 
         final ModificationRequest modificationRequest = new ModificationRequest();
         Mockito.when(paymentPort.capture(modificationRequest)).thenAnswer(new ThrowExceptionForNTimesBeforeReturningResult(numberOfAttempts - 1, new WebServiceException()));
-        final ModificationResult result = adyenPaymentRequestSender.capture("any", modificationRequest);
+        AdyenCallResult<ModificationResult> result = adyenPaymentRequestSender.capture("any", modificationRequest);
 
         Mockito.verify(paymentPort, Mockito.atLeast(numberOfAttempts)).capture(modificationRequest);
         Assert.assertNotNull(result);
@@ -114,7 +114,7 @@ public class TestAdyenPaymentRequestSender {
 
         final ModificationRequest modificationRequest = new ModificationRequest();
         Mockito.when(paymentPort.refund(modificationRequest)).thenAnswer(new ThrowExceptionForNTimesBeforeReturningResult(numberOfAttempts - 1, new WebServiceException()));
-        final ModificationResult result = adyenPaymentRequestSender.refund("any", modificationRequest);
+        AdyenCallResult<ModificationResult> result = adyenPaymentRequestSender.refund("any", modificationRequest);
 
         Mockito.verify(paymentPort, Mockito.atLeast(numberOfAttempts)).refund(modificationRequest);
         Assert.assertNotNull(result);

--- a/src/test/java/org/killbill/billing/plugin/adyen/client/payment/service/TestAdyenPaymentServiceProviderPort.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/client/payment/service/TestAdyenPaymentServiceProviderPort.java
@@ -16,6 +16,7 @@
 
 package org.killbill.billing.plugin.adyen.client.payment.service;
 
+import com.google.common.base.Optional;
 import org.killbill.adyen.payment.Card;
 import org.killbill.adyen.payment.PaymentRequest;
 import org.killbill.adyen.payment.PaymentResult;
@@ -32,10 +33,11 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
 
 public class TestAdyenPaymentServiceProviderPort {
 
@@ -45,9 +47,9 @@ public class TestAdyenPaymentServiceProviderPort {
 
     @BeforeMethod(groups = "fast")
     public void setup() throws ServiceException {
-        final PaymentInfoConverterManagement paymentInfoConverterManagement = Mockito.mock(PaymentInfoConverterManagement.class);
-        final PaymentProvider paymentProvider = Mockito.mock(PaymentProvider.class);
-        final AdyenPaymentRequestSender adyenPaymentRequestSender = Mockito.mock(AdyenPaymentRequestSender.class);
+        final PaymentInfoConverterManagement paymentInfoConverterManagement = mock(PaymentInfoConverterManagement.class);
+        final PaymentProvider paymentProvider = mock(PaymentProvider.class);
+        final AdyenPaymentRequestSender adyenPaymentRequestSender = mock(AdyenPaymentRequestSender.class);
 
         paymentRequest = new PaymentRequest();
         paymentRequest.setReference("12345");
@@ -59,11 +61,14 @@ public class TestAdyenPaymentServiceProviderPort {
         this.paymentData.setPaymentInfo(paymentInfo);
 
         this.adyenPaymentServiceProviderPort = Mockito.spy(new AdyenPaymentServiceProviderPort(paymentInfoConverterManagement,
-                                                                                               mock(AdyenRequestFactory.class),
-                                                                                               adyenPaymentRequestSender));
+                mock(AdyenRequestFactory.class),
+                adyenPaymentRequestSender));
         final PaymentResult paymentResult = new PaymentResult();
         paymentResult.setResultCode(PaymentServiceProviderResult.REDIRECT_SHOPPER.getId());
-        when(adyenPaymentRequestSender.authorise(anyString(), any(PaymentRequest.class))).thenReturn(paymentResult);
+        AdyenCallResult adyenCallResult = mock(AdyenCallResult.class);
+        when(adyenCallResult.receivedWellFormedResponse()).thenReturn(true);
+        when(adyenCallResult.getResult()).thenReturn(Optional.of(paymentResult));
+        when(adyenPaymentRequestSender.authorise(anyString(), any(PaymentRequest.class))).thenReturn(adyenCallResult);
     }
 
     @Test(groups = "fast")

--- a/src/test/java/org/killbill/billing/plugin/adyen/client/payment/service/TestRemoteAdyenPaymentServiceProviderPort.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/client/payment/service/TestRemoteAdyenPaymentServiceProviderPort.java
@@ -16,9 +16,6 @@
 
 package org.killbill.billing.plugin.adyen.client.payment.service;
 
-import java.util.Currency;
-import java.util.UUID;
-
 import org.killbill.billing.plugin.adyen.TestRemoteBase;
 import org.killbill.billing.plugin.adyen.client.model.OrderData;
 import org.killbill.billing.plugin.adyen.client.model.PaymentData;
@@ -29,9 +26,13 @@ import org.killbill.billing.plugin.adyen.client.model.PurchaseResult;
 import org.killbill.billing.plugin.adyen.client.model.SplitSettlementData;
 import org.killbill.billing.plugin.adyen.client.model.UserData;
 import org.killbill.billing.plugin.adyen.client.model.paymentinfo.CreditCard;
-import org.killbill.billing.plugin.adyen.client.payment.exception.ModificationFailedException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import java.util.Currency;
+import java.util.UUID;
+
+import static org.testng.Assert.assertFalse;
 
 public class TestRemoteAdyenPaymentServiceProviderPort extends TestRemoteBase {
 
@@ -113,6 +114,7 @@ public class TestRemoteAdyenPaymentServiceProviderPort extends TestRemoteBase {
         Assert.assertNotNull(authorizeResult.getAuthCode());
         Assert.assertNull(authorizeResult.getReason());
 
+        //noinspection UnnecessaryLocalVariable
         final long captureAmount = authAmount;
         final PaymentProvider paymentProvider = paymentData.getPaymentInfo().getPaymentProvider();
         final String capturePspReference = authorizeResult.getPspReference();
@@ -121,6 +123,7 @@ public class TestRemoteAdyenPaymentServiceProviderPort extends TestRemoteBase {
         Assert.assertNotNull(captureResult.getPspReference());
         Assert.assertEquals(captureResult.getResponse(), "[capture-received]");
 
+        //noinspection UnnecessaryLocalVariable
         final long refundAmount = captureAmount;
         final String refundPspReference = captureResult.getPspReference();
 
@@ -149,12 +152,8 @@ public class TestRemoteAdyenPaymentServiceProviderPort extends TestRemoteBase {
         final PaymentProvider paymentProvider = paymentData.getPaymentInfo().getPaymentProvider();
         final String pspReference = UUID.randomUUID().toString();
 
-        try {
-            final PaymentModificationResponse voidResult = adyenPaymentServiceProviderPort.cancel(paymentProvider, pspReference, splitSettlementData);
-            Assert.fail();
-        } catch (final ModificationFailedException e) {
-            Assert.assertEquals(e.getMessage(), "javax.xml.ws.soap.SOAPFaultException: validation 167 Original pspReference required for this operation");
-        }
+        PaymentModificationResponse response = adyenPaymentServiceProviderPort.cancel(paymentProvider, pspReference, splitSettlementData);
+        assertFalse(response.isSuccess());
     }
 
     private CreditCard getCreditCard() {


### PR DESCRIPTION
    - used wiremock as chaotic proxy (not so great but we will have
      toxiproxy in the real ITs)
    - restuctured the code to have a more concise result handling (before
      modification error were handled by checked exceptions
    - added the abbility to configure purchase timeouts
    - introduced a new test builder (which is still highly redundant and has
      to be cleaned up in furhter PRs). Was required as i had to configure
      the adyen uri.
    - warnings cleaned up