### PR TITLE
#19 Use RecurringType from PaymentProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,18 @@ Notes:
 * Change *paymentProviderType* to the type of payment method in the HPP (see [PaymentType.java](https://github.com/killbill/killbill-adyen-plugin/blob/master/src/main/java/org/killbill/billing/plugin/adyen/client/model/PaymentType.java))
 * At this point, no payment has been created in Kill Bill. The payment will be recorded when processing the notification
 
+### Recurring
+
+For [Adyen's Recurring Functionality](https://docs.adyen.com/display/TD/Recurring+Manual) the following recurring types are provided (see [RecurringType.java](https://github.com/killbill/killbill-adyen-plugin/blob/master/src/main/java/org/killbill/billing/plugin/adyen/client/model/RecurringType.java))
+* `ONECLICK`
+* `RECURRING`
+
+There are 3 different use cases:
+
+1. Use Adyen's recurring payments feature with contract `RECURRING`: CVV is not required (it's an implicit `contAuth`)
+2. Use Adyen's recurring payment feature with contract `ONECLICK`: CVV is always required
+3. Use you own card-on-file system + `contAuth` to simulate option 1. Instead of providing Adyen's `recurringDetailId` the merchant retrieves stored payment data from it's store and populates the fields like a normal payment request. `contAuth` is needed to turn Adyen's (not needed) validations off.
+
 Plugin properties
 -----------------
 
@@ -360,3 +372,5 @@ Plugin properties
 | userAgent                | User-Agent for 3D-Secure Browser Info         |
 | acceptHeader             | Accept-Header for 3D-Secure Browser Info      |
 | contAuth                 | Continuous authentication enabled (boolean)   |
+| recurringDetailId        | ID of payment details stored at Adyen         |
+| recurringType            | Contract to be used for Recurring             |

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/builder/AdyenRequestFactory.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/builder/AdyenRequestFactory.java
@@ -78,7 +78,7 @@ public class AdyenRequestFactory {
         final PaymentInfo paymentInfo = paymentData.getPaymentInfo();
         return new PaymentRequestBuilder(paymentInfo, paymentInfoConverterManagement, orderData.getHolderName()).withAmount(paymentInfo.getPaymentProvider().getCurrency().getCurrencyCode(), amount)
                                                                                                                 .withMerchantAccount(getMerchantAccount(paymentInfo))
-                                                                                                                .withRecurringContractForUser(userData)
+                                                                                                                .withRecurringContractForUser()
                                                                                                                 .withSelectedRecurringDetailReference()
                                                                                                                 .withReference(paymentData.getPaymentTxnInternalRef())
                                                                                                                 .withShopperEmail(userData.getEmail())

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/builder/PaymentRequest3DBuilder.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/builder/PaymentRequest3DBuilder.java
@@ -137,7 +137,7 @@ public class PaymentRequest3DBuilder extends RequestBuilder<PaymentRequest3D> {
     public PaymentRequest3DBuilder withRecurring(final PaymentProvider paymentProvider) {
         if (paymentProvider.isRecurringEnabled()) {
             final Recurring recurring = new Recurring();
-            recurring.setContract(PaymentRequestBuilder.RECURRING_CONTRACT);
+            recurring.setContract(paymentProvider.getRecurringType().name());
             request.setRecurring(recurring);
         }
         return this;

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/builder/PaymentRequestBuilder.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/builder/PaymentRequestBuilder.java
@@ -26,7 +26,7 @@ import org.killbill.adyen.payment.PaymentRequest;
 import org.killbill.adyen.payment.Recurring;
 import org.killbill.billing.plugin.adyen.client.model.PaymentInfo;
 import org.killbill.billing.plugin.adyen.client.model.SplitSettlementData;
-import org.killbill.billing.plugin.adyen.client.model.UserData;
+import org.killbill.billing.plugin.adyen.client.model.RecurringType;
 import org.killbill.billing.plugin.adyen.client.model.paymentinfo.Card;
 import org.killbill.billing.plugin.adyen.client.payment.converter.PaymentInfoConverter;
 import org.killbill.billing.plugin.adyen.client.payment.converter.PaymentInfoConverterManagement;
@@ -145,17 +145,17 @@ public class PaymentRequestBuilder extends RequestBuilder<PaymentRequest> {
         return this;
     }
 
-    public PaymentRequestBuilder withRecurringContractForUser(final UserData userData) {
+    public PaymentRequestBuilder withRecurringContractForUser() {
         if (paymentInfo.getPaymentProvider().isRecurringEnabled()) {
-            final Recurring recurring = createRecurring(RECURRING_CONTRACT);
+            final Recurring recurring = createRecurring(paymentInfo.getRecurringType());
             request.setRecurring(recurring);
         }
         return this;
     }
 
-    private Recurring createRecurring(final String recurringContract) {
+    private Recurring createRecurring(final RecurringType recurringContract) {
         final Recurring recurring = new Recurring();
-        recurring.setContract(recurringContract);
+        recurring.setContract(recurringContract.name());
         return recurring;
     }
 

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/builder/PaymentRequestBuilder.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/builder/PaymentRequestBuilder.java
@@ -37,8 +37,6 @@ import com.google.common.base.Strings;
 
 public class PaymentRequestBuilder extends RequestBuilder<PaymentRequest> {
 
-    protected static final String RECURRING_CONTRACT = "RECURRING,ONECLICK";
-
     private static final String CONTINOUS_AUTHENTICATION_ADYEN = "ContAuth";
 
     private static final PaymentInfoConverter NULL_CONVERTER = new NullObjectConverter();

--- a/src/test/java/org/killbill/billing/plugin/adyen/client/payment/builder/BaseTestPaymentRequestBuilder.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/client/payment/builder/BaseTestPaymentRequestBuilder.java
@@ -1,0 +1,24 @@
+package org.killbill.billing.plugin.adyen.client.payment.builder;
+
+
+import org.killbill.billing.plugin.adyen.client.model.RecurringType;
+import org.testng.annotations.DataProvider;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public abstract class BaseTestPaymentRequestBuilder {
+
+    protected static final String DP_RECURRING_TYPES = "RecurringTypes";
+
+    @DataProvider(name = DP_RECURRING_TYPES)
+    public Iterator<Object[]> recurringTypesdataProvider() {
+        final List<Object[]> recurringTypes = new ArrayList<Object[]>(RecurringType.values().length);
+        for (final RecurringType recurringType : RecurringType.values()) {
+            recurringTypes.add(new Object[] {recurringType});
+        }
+        return recurringTypes.iterator();
+    }
+
+}

--- a/src/test/java/org/killbill/billing/plugin/adyen/client/payment/builder/BaseTestPaymentRequestBuilder.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/client/payment/builder/BaseTestPaymentRequestBuilder.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Groupon, Inc
+ *
+ * Groupon licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.killbill.billing.plugin.adyen.client.payment.builder;
 
 

--- a/src/test/java/org/killbill/billing/plugin/adyen/client/payment/builder/TestPaymentRequest3DBuilder.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/client/payment/builder/TestPaymentRequest3DBuilder.java
@@ -22,13 +22,14 @@ import org.killbill.adyen.common.Name;
 import org.killbill.adyen.payment.PaymentRequest3D;
 import org.killbill.billing.catalog.api.Currency;
 import org.killbill.billing.plugin.adyen.client.model.PaymentProvider;
+import org.killbill.billing.plugin.adyen.client.model.RecurringType;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class TestPaymentRequest3DBuilder {
+public class TestPaymentRequest3DBuilder extends BaseTestPaymentRequestBuilder {
 
     private static final String CURRENCY = Currency.EUR.name();
 
@@ -142,16 +143,17 @@ public class TestPaymentRequest3DBuilder {
         Assert.assertEquals(Gender.MALE, paymentRequest3D.getShopperName().getGender(), "Wrong Gender in ShopperName in Request");
     }
 
-    @Test(groups = "fast")
-    public void testWithRecurring() throws Exception {
+    @Test(groups = "fast", dataProvider = DP_RECURRING_TYPES)
+    public void testWithRecurring(final RecurringType recurringType) throws Exception {
         final PaymentProvider recurringEnabledPaymentProvider = mock(PaymentProvider.class);
         when(recurringEnabledPaymentProvider.isRecurringEnabled()).thenReturn(true);
+        when(recurringEnabledPaymentProvider.getRecurringType()).thenReturn(recurringType);
 
         final PaymentRequest3D paymentRequest3D = new PaymentRequest3DBuilder().withRecurring(recurringEnabledPaymentProvider)
                                                                                .build();
 
         Assert.assertNotNull(paymentRequest3D.getRecurring(), "No Recurring in Request");
-        Assert.assertEquals(paymentRequest3D.getRecurring().getContract(), "RECURRING,ONECLICK", "Wrong Contract in Recurring in Request");
+        Assert.assertEquals(paymentRequest3D.getRecurring().getContract(), recurringType.name(), "Wrong Contract in Recurring in Request");
     }
 
     @Test(groups = "fast")

--- a/src/test/java/org/killbill/billing/plugin/adyen/client/payment/builder/TestPaymentRequestBuilder.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/client/payment/builder/TestPaymentRequestBuilder.java
@@ -16,9 +16,7 @@
 
 package org.killbill.billing.plugin.adyen.client.payment.builder;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 
@@ -44,15 +42,13 @@ import org.killbill.billing.plugin.adyen.client.payment.converter.PaymentInfoCon
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
 
-public class TestPaymentRequestBuilder {
+public class TestPaymentRequestBuilder extends BaseTestPaymentRequestBuilder {
 
     private static final String ANY_HOLDER_NAME = "anyHolderName";
-    private static final String DP_RECURRING_TYPES = "RecurringTypes";
 
     private final AdyenConfigProperties adyenConfigProperties = new AdyenConfigProperties(new Properties());
     private final PaymentInfo anyPaymentInfo = new Elv(new PaymentProvider(adyenConfigProperties));
@@ -173,15 +169,6 @@ public class TestPaymentRequestBuilder {
         Assert.assertNotNull(paymentRequest.getRecurring());
         Assert.assertSame(paymentRequest.getRecurring().getContract(), recurringType.name());
     }
-    @DataProvider(name = DP_RECURRING_TYPES)
-    public Iterator<Object[]> recurringTypesdataProvider() {
-        final List<Object[]> recurringTypes = new ArrayList<Object[]>(RecurringType.values().length);
-        for (final RecurringType recurringType : RecurringType.values()) {
-            recurringTypes.add(new Object[] {recurringType});
-        }
-        return recurringTypes.iterator();
-    }
-
 
     @Test(groups = "fast")
     public void shouldContainNoRecurringInformationIfPaymentProviderIsDisabledForRecurring() {


### PR DESCRIPTION
When Recurring is enabled, the `RecurringType` is in the `PaymentProvider` and is now used to set the `RecurringContract` in `PaymentRequest`s.