### PR TITLE
Issue #4 Determine SEPA / ELV / CC without looking at ccType

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,10 +220,6 @@ curl -v \
        "pluginInfo": {
          "properties": [
            {
-             "key": "ccType",
-             "value": "sepadirectdebit"
-           },
-           {
              "key": "ddHolderName",
              "value": "A. Schneider"
            },
@@ -257,10 +253,6 @@ curl -v \
        "pluginName": "killbill-adyen",
        "pluginInfo": {
          "properties": [
-           {
-             "key": "ccType",
-             "value": "elv"
-           },
            {
              "key": "ddHolderName",
              "value": "Bill Killson"

--- a/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentPluginApi.java
@@ -167,7 +167,6 @@ public class AdyenPaymentPluginApi extends PluginPaymentPluginApi<AdyenResponses
     public static final String PROPERTY_CONTINUOUS_AUTHENTICATION = "contAuth";
     private static final String SEPA_DIRECT_DEBIT = "sepadirectdebit";
     private static final String ELV = "elv";
-    private static final String CREDITCARD = "creditcard";
 
     private final AdyenConfigurationHandler adyenConfigurationHandler;
     private final AdyenHostedPaymentPageConfigurationHandler adyenHppConfigurationHandler;
@@ -680,13 +679,14 @@ public class AdyenPaymentPluginApi extends PluginPaymentPluginApi<AdyenResponses
         final String ddHolderName = PluginProperties.getValue(PROPERTY_DD_HOLDER_NAME, paymentMethodHolderName, properties);
         final String ddBic = PluginProperties.findPluginPropertyValue(PROPERTY_DD_BANK_IDENTIFIER_CODE, properties);
         final String ddBlz = PluginProperties.findPluginPropertyValue(PROPERTY_DD_BANKLEITZAHL, properties);
+        final String ccType = PluginProperties.getValue(PROPERTY_CC_TYPE, paymentMethodsRecord.getCcType(), properties);
 
         if (allNotNull(ddAccountNumber, ddHolderName, ddBic)) {
             return SEPA_DIRECT_DEBIT;
         } else if (allNotNull(ddAccountNumber, ddHolderName, ddBlz)) {
             return ELV;
         } else {
-            return CREDITCARD;
+            return ccType;
         }
 
     }
@@ -873,9 +873,8 @@ public class AdyenPaymentPluginApi extends PluginPaymentPluginApi<AdyenResponses
         } else if (pluginPropertyPaymentProviderType != null) {
             paymentProviderPaymentType = PaymentType.getByName(pluginPropertyPaymentProviderType);
         } else {
-            final String pluginPropertyCCType = PluginProperties.findPluginPropertyValue(PROPERTY_CC_TYPE, properties);
-            final String paymentMethodCCType = paymentMethodsRecord == null || paymentMethodsRecord.getCcType() == null ? null : paymentMethodsRecord.getCcType();
-            paymentProviderPaymentType = pluginPropertyCCType == null ? (paymentMethodCCType == null ? PaymentType.CREDITCARD : PaymentType.getByName(paymentMethodCCType)) : PaymentType.getByName(pluginPropertyCCType);
+            final String cardType = determineCardType(paymentMethodsRecord, properties);
+            paymentProviderPaymentType = cardType == null ? PaymentType.CREDITCARD : PaymentType.getByName(cardType);
         }
 
         final RecurringType paymentProviderRecurringType;

--- a/src/test/java/org/killbill/billing/plugin/adyen/TestRemoteBase.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/TestRemoteBase.java
@@ -66,12 +66,10 @@ public abstract class TestRemoteBase {
     public static final String DD_IBAN = "DE87123456781234567890";
     public static final String DD_BIC = "TESTDE01XXX";
     public static final String DD_HOLDER_NAME = "A. Schneider";
-    public static final String DD_TYPE = "sepadirectdebit";
 
     public static final String ELV_ACCOUNT_NUMBER = "1234567890";
     public static final String ELV_BLZ = "12345678";
     public static final String ELV_HOLDER_NAME = "Bill Killson";
-    public static final String ELV_TYPE = "elv";
 
     protected AdyenConfigProperties adyenConfigProperties;
     protected AdyenConfigurationHandler adyenConfigurationHandler;

--- a/src/test/java/org/killbill/billing/plugin/adyen/api/TestAdyenPaymentPluginApi.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/api/TestAdyenPaymentPluginApi.java
@@ -127,8 +127,8 @@ public class TestAdyenPaymentPluginApi extends TestWithEmbeddedDBBase {
                                                          .put(AdyenPaymentPluginApi.PROPERTY_THREE_D_THRESHOLD, "25000")
                                                          .build());
 
-        propertiesWithSepaInfo = toProperties(ImmutableMap.of(AdyenPaymentPluginApi.PROPERTY_CC_TYPE, DD_TYPE));
-        propertiesWithElvInfo = toProperties(ImmutableMap.of(AdyenPaymentPluginApi.PROPERTY_CC_TYPE, ELV_TYPE));
+        propertiesWithSepaInfo = toProperties(ImmutableMap.<String, String>of());
+        propertiesWithElvInfo = toProperties(ImmutableMap.<String, String>of());
         final String customerId = UUID.randomUUID().toString();
         propertiesForRecurring = ImmutableMap.of(AdyenPaymentPluginApi.PROPERTY_CUSTOMER_ID, customerId,
                                                  AdyenPaymentPluginApi.PROPERTY_EMAIL, customerId + "0@example.com");


### PR DESCRIPTION
Instead of relying on `ccType` checks if `ddAccountNumber`, `ddHolderName`, `ddBic` (SEPA), `ddBlz` (ELV) are set.