### PR TITLE
Improve logging

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/adyen/client/jaxws/AuthorizationHeaderObfuscator.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/jaxws/AuthorizationHeaderObfuscator.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014-2016 Groupon, Inc
+ * Copyright 2014-2016 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.plugin.adyen.client.jaxws;
+
+public class AuthorizationHeaderObfuscator implements Obfuscator {
+
+    @Override
+    public String obfuscateAdyenResponseLog(final String response) {
+        return response;
+    }
+
+    @Override
+    public String obfuscateAdyenRequestLog(final String request) {
+        if (request != null) {
+            return request.replaceAll("Authorization=\\[[^\\]]*\\]", "Authorization=[****]");
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/jaxws/LoggingOutInterceptor.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/jaxws/LoggingOutInterceptor.java
@@ -23,7 +23,8 @@ public class LoggingOutInterceptor extends org.apache.cxf.interceptor.LoggingOut
     private final Iterable<Obfuscator> obfuscators;
 
     public LoggingOutInterceptor() {
-        this(ImmutableList.<Obfuscator>of(new PayUObfuscator()));
+        this(ImmutableList.<Obfuscator>of(new PayUObfuscator(),
+                                          new AuthorizationHeaderObfuscator()));
     }
 
     public LoggingOutInterceptor(final Iterable<Obfuscator> obfuscators) {
@@ -34,8 +35,7 @@ public class LoggingOutInterceptor extends org.apache.cxf.interceptor.LoggingOut
     protected String transform(final String originalLogString) {
         String result = originalLogString.replaceAll("cvc>[0-9]+</", "cvc>***</")
                                          .replaceAll("number>[0-9]+</", "number>***</")
-                                         .replaceAll("bankAccountNumber>[0-9]+</", "bankAccountNumber>***</")
-                                         .replaceAll("Authorization=\\[[^\\]]*\\]", "Authorization=[****]");
+                                         .replaceAll("bankAccountNumber>[0-9]+</", "bankAccountNumber>***</");
 
         for (final Obfuscator obfuscator : obfuscators) {
             result = obfuscator.obfuscateAdyenRequestLog(result);

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/jaxws/LoggingOutInterceptor.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/jaxws/LoggingOutInterceptor.java
@@ -34,7 +34,8 @@ public class LoggingOutInterceptor extends org.apache.cxf.interceptor.LoggingOut
     protected String transform(final String originalLogString) {
         String result = originalLogString.replaceAll("cvc>[0-9]+</", "cvc>***</")
                                          .replaceAll("number>[0-9]+</", "number>***</")
-                                         .replaceAll("bankAccountNumber>[0-9]+</", "bankAccountNumber>***</");
+                                         .replaceAll("bankAccountNumber>[0-9]+</", "bankAccountNumber>***</")
+                                         .replaceAll("Authorization=\\[[^\\]]*\\]", "Authorization=[****]");
 
         for (final Obfuscator obfuscator : obfuscators) {
             result = obfuscator.obfuscateAdyenRequestLog(result);

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/notification/AdyenNotificationService.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/notification/AdyenNotificationService.java
@@ -113,7 +113,7 @@ public class AdyenNotificationService {
             if (error == null) {
                 logger.info(message);
             } else {
-                logger.error(message, error);
+                logger.warn(message, error);
             }
         }
 

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/notification/AdyenNotificationService.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/notification/AdyenNotificationService.java
@@ -99,7 +99,7 @@ public class AdyenNotificationService {
             error = e;
         } finally {
             final String message = String.format(
-                    "op='notificationHandling' eventCode='%s', pspReference='%s', originalReference='%s', success='%s', reason='%s', merchantReference='%s', merchantAccount='%s', duration=%d, error=%s",
+                    "op='notificationHandling', eventCode='%s', pspReference='%s', originalReference='%s', success='%s', reason='%s', merchantReference='%s', merchantAccount='%s', duration=%d, error=%s",
                     item.getEventCode(),
                     item.getPspReference(),
                     item.getOriginalReference(),
@@ -146,8 +146,7 @@ public class AdyenNotificationService {
             response.setNotificationResponse(value);
 
             // Use SOAPMessage to add the envelope
-            final Document document;
-                document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+            final Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
             final Marshaller marshaller = jaxbContext.createMarshaller();
             marshaller.marshal(response, document);
 

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/AdyenCallResult.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/AdyenCallResult.java
@@ -24,6 +24,8 @@ public interface AdyenCallResult<T> {
 
     Optional<T> getResult();
 
+    long getDuration();
+
     Optional<AdyenCallErrorStatus> getResponseStatus();
 
     Optional<String> getExceptionClass();
@@ -38,13 +40,21 @@ class SuccessfulAdyenCall<T> implements AdyenCallResult<T> {
 
     private final T result;
 
-    public SuccessfulAdyenCall(final T result) {
+    private final long duration;
+
+    public SuccessfulAdyenCall(final T result, long duration) {
         this.result = checkNotNull(result, "result");
+        this.duration = duration;
     }
 
     @Override
     public Optional<T> getResult() {
         return Optional.of(result);
+    }
+
+    @Override
+    public long getDuration() {
+        return duration;
     }
 
     @Override
@@ -71,7 +81,8 @@ class SuccessfulAdyenCall<T> implements AdyenCallResult<T> {
     public String toString() {
         final StringBuilder sb = new StringBuilder("SuccessfulAdyenCall{");
         sb.append("result=").append(result);
-        sb.append('}');
+        sb.append(", duration=").append(duration);
+        sb.append(" }");
         return sb.toString();
     }
 }
@@ -81,6 +92,7 @@ class UnSuccessfulAdyenCall<T> implements AdyenCallResult<T> {
     private final AdyenCallErrorStatus responseStatus;
     private final String exceptionClass;
     private final String exceptionMessage;
+    private long duration;
 
     UnSuccessfulAdyenCall(final AdyenCallErrorStatus responseStatus, final Throwable rootCause) {
         this.responseStatus = responseStatus;
@@ -91,6 +103,15 @@ class UnSuccessfulAdyenCall<T> implements AdyenCallResult<T> {
     @Override
     public Optional<T> getResult() {
         return Optional.absent();
+    }
+
+    @Override
+    public long getDuration() {
+        return duration;
+    }
+
+    public void setDuration(final long duration) {
+        this.duration = duration;
     }
 
     @Override
@@ -119,7 +140,8 @@ class UnSuccessfulAdyenCall<T> implements AdyenCallResult<T> {
         sb.append("responseStatus=").append(responseStatus);
         sb.append(", exceptionMessage='").append(exceptionMessage).append('\'');
         sb.append(", exceptionClass='").append(exceptionClass).append('\'');
-        sb.append('}');
+        sb.append(", duration=").append(duration);
+        sb.append(" }");
         return sb.toString();
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/AdyenCallResult.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/AdyenCallResult.java
@@ -81,7 +81,6 @@ class SuccessfulAdyenCall<T> implements AdyenCallResult<T> {
     public String toString() {
         final StringBuilder sb = new StringBuilder("SuccessfulAdyenCall{");
         sb.append("result=").append(result);
-        sb.append(", duration=").append(duration);
         sb.append(" }");
         return sb.toString();
     }
@@ -140,7 +139,6 @@ class UnSuccessfulAdyenCall<T> implements AdyenCallResult<T> {
         sb.append("responseStatus=").append(responseStatus);
         sb.append(", exceptionMessage='").append(exceptionMessage).append('\'');
         sb.append(", exceptionClass='").append(exceptionClass).append('\'');
-        sb.append(", duration=").append(duration);
         sb.append(" }");
         return sb.toString();
     }

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/AdyenPaymentRequestSender.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/AdyenPaymentRequestSender.java
@@ -131,7 +131,7 @@ public class AdyenPaymentRequestSender implements Closeable {
             return new SuccessfulAdyenCall<T>(result, duration);
         } catch (final Exception e) {
             final long duration = System.currentTimeMillis() - startTime;
-            logger.error("Exception during Adyen request", e);
+            logger.warn("Exception during Adyen request", e);
 
             final UnSuccessfulAdyenCall<T> unsuccessfulResult = mapExceptionToCallResult(e);
             unsuccessfulResult.setDuration(duration);

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/AdyenPaymentRequestSender.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/AdyenPaymentRequestSender.java
@@ -122,13 +122,20 @@ public class AdyenPaymentRequestSender implements Closeable {
     }
 
     private <T> AdyenCallResult<T> callAdyen(final String merchantAccount, final AdyenCall<PaymentPortType, T> adyenCall) {
+        final long startTime = System.currentTimeMillis();
         try {
             final PaymentPortType paymentPort = adyenPaymentPortRegistry.getPaymentPort(merchantAccount);
             final T result = adyenCall.apply(paymentPort);
-            return new SuccessfulAdyenCall<T>(result);
+
+            final long duration = System.currentTimeMillis() - startTime;
+            return new SuccessfulAdyenCall<T>(result, duration);
         } catch (final Exception e) {
-            logger.warn("Exception during Adyen request", e);
-            return mapExceptionToCallResult(e);
+            final long duration = System.currentTimeMillis() - startTime;
+            logger.error("Exception during Adyen request", e);
+
+            final UnSuccessfulAdyenCall<T> unsuccessfulResult = mapExceptionToCallResult(e);
+            unsuccessfulResult.setDuration(duration);
+            return unsuccessfulResult;
         }
     }
 
@@ -136,7 +143,7 @@ public class AdyenPaymentRequestSender implements Closeable {
      * Educated guess approach to transform CXF exceptions into error status codes.
      * In the future if we encounter further different cases it makes sense to change this if/else structure to a map with lookup.
      */
-    private <T> AdyenCallResult<T> mapExceptionToCallResult(final Exception e) {
+    private <T> UnSuccessfulAdyenCall<T> mapExceptionToCallResult(final Exception e) {
         //noinspection ThrowableResultOfMethodCallIgnored
         final Throwable rootCause = Throwables.getRootCause(e);
         final String errorMessage = rootCause.getMessage();

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/AdyenPaymentServiceProviderHostedPaymentPagePort.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/AdyenPaymentServiceProviderHostedPaymentPagePort.java
@@ -42,8 +42,6 @@ import static org.killbill.billing.plugin.util.KillBillMoney.toMinorUnits;
 
 public class AdyenPaymentServiceProviderHostedPaymentPagePort extends BaseAdyenPaymentServiceProviderPort implements Closeable {
 
-    private static final Logger logger = LoggerFactory.getLogger(AdyenPaymentServiceProviderHostedPaymentPagePort.class);
-
     private final AdyenConfigProperties adyenConfigProperties;
     private final AdyenRequestFactory adyenRequestFactory;
     private final DirectoryClient directoryClient;
@@ -54,6 +52,8 @@ public class AdyenPaymentServiceProviderHostedPaymentPagePort extends BaseAdyenP
         this.adyenConfigProperties = adyenConfigProperties;
         this.adyenRequestFactory = adyenRequestFactory;
         this.directoryClient = directoryClient;
+
+        this.logger = LoggerFactory.getLogger(AdyenPaymentServiceProviderHostedPaymentPagePort.class);
     }
 
     @Override
@@ -64,7 +64,7 @@ public class AdyenPaymentServiceProviderHostedPaymentPagePort extends BaseAdyenP
     }
 
     public Map<String, String> getFormParameter(final String merchantAccount, final PaymentData paymentData, final UserData userData, final SplitSettlementData splitSettlementData) throws SignatureGenerationException {
-        logOperation(logger, "createHppRequest", paymentData, userData, null);
+        logTransaction("createHppRequest", userData, paymentData, null, null);
         return adyenRequestFactory.createHppRequest(merchantAccount, paymentData, userData, splitSettlementData);
     }
 

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/AdyenPaymentServiceProviderHostedPaymentPagePort.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/AdyenPaymentServiceProviderHostedPaymentPagePort.java
@@ -64,7 +64,7 @@ public class AdyenPaymentServiceProviderHostedPaymentPagePort extends BaseAdyenP
     }
 
     public Map<String, String> getFormParameter(final String merchantAccount, final PaymentData paymentData, final UserData userData, final SplitSettlementData splitSettlementData) throws SignatureGenerationException {
-        logTransaction("createHppRequest", userData, paymentData, null, null);
+        logTransaction("createHppRequest", userData, merchantAccount, paymentData, null, null);
         return adyenRequestFactory.createHppRequest(merchantAccount, paymentData, userData, splitSettlementData);
     }
 

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/AdyenPaymentServiceProviderPort.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/AdyenPaymentServiceProviderPort.java
@@ -89,7 +89,7 @@ public class AdyenPaymentServiceProviderPort extends BaseAdyenPaymentServiceProv
         }
 
         if (!adyenCallResult.receivedWellFormedResponse()) {
-            return handleTechnicalFailureAtPurchase(operation, userData, paymentData, adyenCallResult);
+            return handleTechnicalFailureAtPurchase(operation, userData, merchantAccount, paymentData, adyenCallResult);
         }
 
         final PurchaseResult purchaseResult;
@@ -125,7 +125,7 @@ public class AdyenPaymentServiceProviderPort extends BaseAdyenPaymentServiceProv
                                                 getAdditionalData(result));
         }
 
-        logTransaction(operation, userData, paymentData, purchaseResult, adyenCallResult);
+        logTransaction(operation, userData, merchantAccount, paymentData, purchaseResult, adyenCallResult);
         return purchaseResult;
     }
 
@@ -153,8 +153,8 @@ public class AdyenPaymentServiceProviderPort extends BaseAdyenPaymentServiceProv
         return additionalDataMap;
     }
 
-    private PurchaseResult handleTechnicalFailureAtPurchase(final String transactionType, final UserData userData, final PaymentData paymentData, final AdyenCallResult<PaymentResult> adyenCall) {
-        logTransactionError(transactionType, userData, paymentData, adyenCall);
+    private PurchaseResult handleTechnicalFailureAtPurchase(final String transactionType, final UserData userData, final String merchantAccount, final PaymentData paymentData, final AdyenCallResult<PaymentResult> adyenCall) {
+        logTransactionError(transactionType, userData, merchantAccount, paymentData, adyenCall);
         return new PurchaseResult(paymentData.getPaymentTransactionExternalKey(), adyenCall);
     }
 
@@ -170,7 +170,7 @@ public class AdyenPaymentServiceProviderPort extends BaseAdyenPaymentServiceProv
         final AdyenCallResult<PaymentResult> adyenCallResult = adyenPaymentRequestSender.authorise3D(merchantAccount, request);
 
         if (!adyenCallResult.receivedWellFormedResponse()) {
-            return handleTechnicalFailureAtPurchase(operation, userData, paymentData, adyenCallResult);
+            return handleTechnicalFailureAtPurchase(operation, userData, merchantAccount, paymentData, adyenCallResult);
         }
 
         final PurchaseResult purchaseResult;
@@ -200,7 +200,7 @@ public class AdyenPaymentServiceProviderPort extends BaseAdyenPaymentServiceProv
                                                 getAdditionalData(result));
         }
 
-        logTransaction(operation, userData, paymentData, purchaseResult, adyenCallResult);
+        logTransaction(operation, userData, merchantAccount, paymentData, purchaseResult, adyenCallResult);
         return purchaseResult;
     }
 
@@ -265,14 +265,14 @@ public class AdyenPaymentServiceProviderPort extends BaseAdyenPaymentServiceProv
         final AdyenCallResult<ModificationResult> adyenCall = modificationExecutor.execute(modificationRequest);
 
         if (!adyenCall.receivedWellFormedResponse()) {
-            logTransactionError(operation, pspReference, paymentData, adyenCall);
+            logTransactionError(operation, pspReference, merchantAccount, paymentData, adyenCall);
             return new PaymentModificationResponse(pspReference, adyenCall);
         } else {
             final ModificationResult result = adyenCall.getResult().get();
             final PaymentModificationResponse response = new PaymentModificationResponse(result.getResponse(),
                                                                                          result.getPspReference(),
                                                                                          entriesToMap(result.getAdditionalData()));
-            logTransaction(operation, pspReference, paymentData, response, adyenCall);
+            logTransaction(operation, pspReference, merchantAccount, paymentData, response, adyenCall);
             return response;
         }
     }

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/AdyenPaymentServiceProviderPort.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/AdyenPaymentServiceProviderPort.java
@@ -39,12 +39,9 @@ import org.killbill.billing.plugin.adyen.client.model.PurchaseResult;
 import org.killbill.billing.plugin.adyen.client.model.SplitSettlementData;
 import org.killbill.billing.plugin.adyen.client.model.UserData;
 import org.killbill.billing.plugin.adyen.client.payment.builder.AdyenRequestFactory;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class AdyenPaymentServiceProviderPort extends BaseAdyenPaymentServiceProviderPort implements Closeable {
-
-    private static final Logger logger = LoggerFactory.getLogger(AdyenPaymentServiceProviderPort.class);
 
     private final AdyenRequestFactory adyenRequestFactory;
     private final AdyenPaymentRequestSender adyenPaymentRequestSender;
@@ -53,6 +50,8 @@ public class AdyenPaymentServiceProviderPort extends BaseAdyenPaymentServiceProv
                                            final AdyenPaymentRequestSender adyenPaymentRequestSender) {
         this.adyenRequestFactory = adyenRequestFactory;
         this.adyenPaymentRequestSender = adyenPaymentRequestSender;
+
+        this.logger = LoggerFactory.getLogger(AdyenPaymentServiceProviderPort.class);
     }
 
     @Override
@@ -80,8 +79,6 @@ public class AdyenPaymentServiceProviderPort extends BaseAdyenPaymentServiceProv
                                              final UserData userData,
                                              final SplitSettlementData splitSettlementData) {
         final String operation = authorize ? "authorize" : "credit";
-        logOperation(logger, operation, paymentData, userData, null);
-
         final PaymentRequest request = adyenRequestFactory.createPaymentRequest(merchantAccount, paymentData, userData, splitSettlementData);
 
         final AdyenCallResult<PaymentResult> adyenCallResult;
@@ -92,7 +89,7 @@ public class AdyenPaymentServiceProviderPort extends BaseAdyenPaymentServiceProv
         }
 
         if (!adyenCallResult.receivedWellFormedResponse()) {
-            return handleTechnicalFailureAtPurchase(operation, paymentData, adyenCallResult);
+            return handleTechnicalFailureAtPurchase(operation, userData, paymentData, adyenCallResult);
         }
 
         final PurchaseResult purchaseResult;
@@ -128,7 +125,7 @@ public class AdyenPaymentServiceProviderPort extends BaseAdyenPaymentServiceProv
                                                 getAdditionalData(result));
         }
 
-        logger.info("op='{}', {}", operation, purchaseResult);
+        logTransaction(operation, userData, paymentData, purchaseResult, adyenCallResult);
         return purchaseResult;
     }
 
@@ -156,9 +153,9 @@ public class AdyenPaymentServiceProviderPort extends BaseAdyenPaymentServiceProv
         return additionalDataMap;
     }
 
-    private PurchaseResult handleTechnicalFailureAtPurchase(final String callKey, final PaymentData paymentData, final AdyenCallResult<PaymentResult> adyenCallResult) {
-        logger.warn("op='{}', paymentTransactionExternalKey='{}', {}", callKey, paymentData.getPaymentTransactionExternalKey(), adyenCallResult);
-        return new PurchaseResult(paymentData.getPaymentTransactionExternalKey(), adyenCallResult);
+    private PurchaseResult handleTechnicalFailureAtPurchase(final String transactionType, final UserData userData, final PaymentData paymentData, final AdyenCallResult<PaymentResult> adyenCall) {
+        logTransactionError(transactionType, userData, paymentData, adyenCall);
+        return new PurchaseResult(paymentData.getPaymentTransactionExternalKey(), adyenCall);
     }
 
     public PurchaseResult authorize3DSecure(final String merchantAccount,
@@ -166,8 +163,6 @@ public class AdyenPaymentServiceProviderPort extends BaseAdyenPaymentServiceProv
                                             final UserData userData,
                                             final SplitSettlementData splitSettlementData) {
         final String operation = "authorize3DSecure";
-        logOperation(logger, operation, paymentData, userData, null);
-
         final PaymentRequest3D request = adyenRequestFactory.paymentRequest3d(merchantAccount,
                                                                               paymentData,
                                                                               userData,
@@ -175,7 +170,7 @@ public class AdyenPaymentServiceProviderPort extends BaseAdyenPaymentServiceProv
         final AdyenCallResult<PaymentResult> adyenCallResult = adyenPaymentRequestSender.authorise3D(merchantAccount, request);
 
         if (!adyenCallResult.receivedWellFormedResponse()) {
-            return handleTechnicalFailureAtPurchase(operation, paymentData, adyenCallResult);
+            return handleTechnicalFailureAtPurchase(operation, userData, paymentData, adyenCallResult);
         }
 
         final PurchaseResult purchaseResult;
@@ -205,7 +200,7 @@ public class AdyenPaymentServiceProviderPort extends BaseAdyenPaymentServiceProv
                                                 getAdditionalData(result));
         }
 
-        logger.info("op='{}', {}", operation, purchaseResult);
+        logTransaction(operation, userData, paymentData, purchaseResult, adyenCallResult);
         return purchaseResult;
     }
 
@@ -266,20 +261,18 @@ public class AdyenPaymentServiceProviderPort extends BaseAdyenPaymentServiceProv
                                                final PaymentData paymentData,
                                                final String pspReference,
                                                final SplitSettlementData splitSettlementData) {
-        logOperation(logger, operation, paymentData, null, pspReference);
-
         final ModificationRequest modificationRequest = adyenRequestFactory.createModificationRequest(merchantAccount, paymentData, pspReference, splitSettlementData);
-        final AdyenCallResult<ModificationResult> adyenCallResult = modificationExecutor.execute(modificationRequest);
+        final AdyenCallResult<ModificationResult> adyenCall = modificationExecutor.execute(modificationRequest);
 
-        if (!adyenCallResult.receivedWellFormedResponse()) {
-            logger.warn("op='{}', success='false', {}", operation, adyenCallResult);
-            return new PaymentModificationResponse(pspReference, adyenCallResult);
+        if (!adyenCall.receivedWellFormedResponse()) {
+            logTransactionError(operation, pspReference, paymentData, adyenCall);
+            return new PaymentModificationResponse(pspReference, adyenCall);
         } else {
-            final ModificationResult result = adyenCallResult.getResult().get();
+            final ModificationResult result = adyenCall.getResult().get();
             final PaymentModificationResponse response = new PaymentModificationResponse(result.getResponse(),
                                                                                          result.getPspReference(),
                                                                                          entriesToMap(result.getAdditionalData()));
-            logger.info("op='{}', success='true', {}", operation, response);
+            logTransaction(operation, pspReference, paymentData, response, adyenCall);
             return response;
         }
     }

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/BaseAdyenPaymentServiceProviderPort.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/BaseAdyenPaymentServiceProviderPort.java
@@ -20,33 +20,122 @@ package org.killbill.billing.plugin.adyen.client.payment.service;
 import javax.annotation.Nullable;
 
 import org.killbill.billing.plugin.adyen.client.model.PaymentData;
+import org.killbill.billing.plugin.adyen.client.model.PaymentModificationResponse;
+import org.killbill.billing.plugin.adyen.client.model.PurchaseResult;
 import org.killbill.billing.plugin.adyen.client.model.UserData;
 import org.slf4j.Logger;
 
 public abstract class BaseAdyenPaymentServiceProviderPort {
 
-    protected void logOperation(final Logger logger, final String operation, @Nullable final PaymentData paymentData, @Nullable final UserData userData, @Nullable final String pspReference) {
-        final StringBuilder stringBuilder = new StringBuilder("op='").append(operation).append("'");
-        if (paymentData != null && paymentData.getAmount() != null) {
-            stringBuilder.append(", amount='")
-                         .append(paymentData.getAmount())
-                         .append("'");
+    protected Logger logger;
+
+    protected void logTransaction(final String transactionType, final UserData userData, final PaymentData paymentData, @Nullable final PurchaseResult result, @Nullable final AdyenCallResult<?> adyenCall) {
+        final StringBuilder logBuffer = new StringBuilder();
+        appendTransactionType(logBuffer, transactionType);
+        appendPaymentData(logBuffer, paymentData);
+        appendUserData(logBuffer, userData);
+        appendPurchaseResult(logBuffer, result);
+        if (adyenCall != null) {
+            appendDuration(logBuffer, adyenCall.getDuration());
         }
-        if (paymentData != null && paymentData.getPaymentTransactionExternalKey() != null) {
-            stringBuilder.append(", paymentTransactionExternalKey='")
-                         .append(paymentData.getPaymentTransactionExternalKey())
-                         .append("'");
+        logBuffer.append(", error=false");
+
+        logger.info(logBuffer.toString());
+    }
+
+    protected void logTransaction(final String transactionType, final String pspReference, final PaymentData paymentData, final PaymentModificationResponse response, final AdyenCallResult<?> adyenCall) {
+        final StringBuilder logBuffer = new StringBuilder();
+        appendTransactionType(logBuffer, transactionType);
+        appendPaymentData(logBuffer, paymentData);
+        appendPspReference(logBuffer, pspReference);
+        appendModificationResponse(logBuffer, response);
+        appendDuration(logBuffer, adyenCall.getDuration());
+        logBuffer.append(", error=false");
+
+        logger.info(logBuffer.toString());
+    }
+
+    protected void logTransactionError(final String transactionType, final UserData userData, final PaymentData paymentData, final AdyenCallResult<?> adyenCall) {
+        final StringBuilder logBuffer = new StringBuilder();
+        appendTransactionType(logBuffer, transactionType);
+        appendPaymentData(logBuffer, paymentData);
+        appendUserData(logBuffer, userData);
+        appendAdyenCall(logBuffer, adyenCall);
+        logBuffer.append(", error=true");
+
+        logger.info(logBuffer.toString());
+    }
+
+    protected void logTransactionError(final String transactionType, final String pspReference, final PaymentData paymentData, final AdyenCallResult<?> adyenCall) {
+        final StringBuilder logBuffer = new StringBuilder();
+        appendTransactionType(logBuffer, transactionType);
+        appendPspReference(logBuffer, pspReference);
+        appendPaymentData(logBuffer, paymentData);
+        appendPspReference(logBuffer, pspReference);
+        appendAdyenCall(logBuffer, adyenCall);
+        logBuffer.append(", error=true");
+
+        logger.info(logBuffer.toString());
+    }
+
+    private void appendTransactionType(final StringBuilder buffer, final String transactionType) {
+        buffer.append("op='").append(transactionType).append("'");
+    }
+
+    private void appendPaymentData(final StringBuilder buffer, final PaymentData paymentData) {
+        if (paymentData == null ) {
+            return;
         }
+
+        if (paymentData.getAmount() != null) {
+            buffer.append(", amount='")
+                  .append(paymentData.getAmount())
+                  .append("'");
+        }
+        if (paymentData.getAmount() != null) {
+            buffer.append(", amount='")
+                  .append(paymentData.getAmount())
+                  .append("'");
+        }
+        if (paymentData.getPaymentTransactionExternalKey() != null) {
+            buffer.append(", paymentTransactionExternalKey='")
+                  .append(paymentData.getPaymentTransactionExternalKey())
+                  .append("'");
+        }
+    }
+
+    private void appendUserData(final StringBuilder buffer, final UserData userData) {
         if (userData != null && userData.getShopperReference() != null) {
-            stringBuilder.append(", customerId='")
-                         .append(userData.getShopperReference())
-                         .append("'");
+            buffer.append(", customerId='")
+                  .append(userData.getShopperReference())
+                  .append("'");
         }
+    }
+
+
+    private void appendPspReference(final StringBuilder buffer, final String pspReference) {
         if (pspReference != null) {
-            stringBuilder.append(", pspReference='")
-                         .append(pspReference)
-                         .append("'");
+            buffer.append(", pspReference='")
+                  .append(pspReference)
+                  .append("'");
         }
-        logger.info(stringBuilder.toString());
+    }
+
+    private void appendPurchaseResult(final StringBuilder buffer, @Nullable final PurchaseResult result) {
+        if (result != null) {
+            buffer.append(", ").append(result);
+        }
+    }
+
+    private void appendModificationResponse(final StringBuilder buffer, final PaymentModificationResponse response) {
+        buffer.append(", ").append(response);
+    }
+
+    private void appendDuration(final StringBuilder buffer, final long duration) {
+        buffer.append(", duration=").append(duration);
+    }
+
+    private void appendAdyenCall(final StringBuilder buffer, final AdyenCallResult<?> adyenCall) {
+        buffer.append(", ").append(adyenCall);
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/BaseAdyenPaymentServiceProviderPort.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/BaseAdyenPaymentServiceProviderPort.java
@@ -29,9 +29,10 @@ public abstract class BaseAdyenPaymentServiceProviderPort {
 
     protected Logger logger;
 
-    protected void logTransaction(final String transactionType, final UserData userData, final PaymentData paymentData, @Nullable final PurchaseResult result, @Nullable final AdyenCallResult<?> adyenCall) {
+    protected void logTransaction(final String transactionType, final UserData userData, final String merchantAccount, final PaymentData paymentData, @Nullable final PurchaseResult result, @Nullable final AdyenCallResult<?> adyenCall) {
         final StringBuilder logBuffer = new StringBuilder();
         appendTransactionType(logBuffer, transactionType);
+        appendMerchantAccount(logBuffer, merchantAccount);
         appendPaymentData(logBuffer, paymentData);
         appendUserData(logBuffer, userData);
         appendPurchaseResult(logBuffer, result);
@@ -43,9 +44,10 @@ public abstract class BaseAdyenPaymentServiceProviderPort {
         logger.info(logBuffer.toString());
     }
 
-    protected void logTransaction(final String transactionType, final String pspReference, final PaymentData paymentData, final PaymentModificationResponse response, final AdyenCallResult<?> adyenCall) {
+    protected void logTransaction(final String transactionType, final String pspReference, String merchantAccount, final PaymentData paymentData, final PaymentModificationResponse response, final AdyenCallResult<?> adyenCall) {
         final StringBuilder logBuffer = new StringBuilder();
         appendTransactionType(logBuffer, transactionType);
+        appendMerchantAccount(logBuffer, merchantAccount);
         appendPaymentData(logBuffer, paymentData);
         appendPspReference(logBuffer, pspReference);
         appendModificationResponse(logBuffer, response);
@@ -55,9 +57,10 @@ public abstract class BaseAdyenPaymentServiceProviderPort {
         logger.info(logBuffer.toString());
     }
 
-    protected void logTransactionError(final String transactionType, final UserData userData, final PaymentData paymentData, final AdyenCallResult<?> adyenCall) {
+    protected void logTransactionError(final String transactionType, final UserData userData, String merchantAccount, final PaymentData paymentData, final AdyenCallResult<?> adyenCall) {
         final StringBuilder logBuffer = new StringBuilder();
         appendTransactionType(logBuffer, transactionType);
+        appendMerchantAccount(logBuffer, merchantAccount);
         appendPaymentData(logBuffer, paymentData);
         appendUserData(logBuffer, userData);
         appendAdyenCall(logBuffer, adyenCall);
@@ -66,9 +69,10 @@ public abstract class BaseAdyenPaymentServiceProviderPort {
         logger.info(logBuffer.toString());
     }
 
-    protected void logTransactionError(final String transactionType, final String pspReference, final PaymentData paymentData, final AdyenCallResult<?> adyenCall) {
+    protected void logTransactionError(final String transactionType, final String pspReference, String merchantAccount, final PaymentData paymentData, final AdyenCallResult<?> adyenCall) {
         final StringBuilder logBuffer = new StringBuilder();
         appendTransactionType(logBuffer, transactionType);
+        appendMerchantAccount(logBuffer, merchantAccount);
         appendPspReference(logBuffer, pspReference);
         appendPaymentData(logBuffer, paymentData);
         appendPspReference(logBuffer, pspReference);
@@ -80,6 +84,10 @@ public abstract class BaseAdyenPaymentServiceProviderPort {
 
     private void appendTransactionType(final StringBuilder buffer, final String transactionType) {
         buffer.append("op='").append(transactionType).append("'");
+    }
+
+    private void appendMerchantAccount(final StringBuilder buffer, final String merchantAccount) {
+        buffer.append("merchantAccount='").append(merchantAccount).append("'");
     }
 
     private void appendPaymentData(final StringBuilder buffer, final PaymentData paymentData) {

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/BaseAdyenPaymentServiceProviderPort.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/BaseAdyenPaymentServiceProviderPort.java
@@ -64,6 +64,7 @@ public abstract class BaseAdyenPaymentServiceProviderPort {
         appendPaymentData(logBuffer, paymentData);
         appendUserData(logBuffer, userData);
         appendAdyenCall(logBuffer, adyenCall);
+        appendDuration(logBuffer, adyenCall.getDuration());
         logBuffer.append(", error=true");
 
         logger.warn(logBuffer.toString());
@@ -76,6 +77,7 @@ public abstract class BaseAdyenPaymentServiceProviderPort {
         appendPaymentData(logBuffer, paymentData);
         appendPspReference(logBuffer, pspReference);
         appendAdyenCall(logBuffer, adyenCall);
+        appendDuration(logBuffer, adyenCall.getDuration());
         logBuffer.append(", error=true");
 
         logger.warn(logBuffer.toString());

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/BaseAdyenPaymentServiceProviderPort.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/BaseAdyenPaymentServiceProviderPort.java
@@ -87,7 +87,7 @@ public abstract class BaseAdyenPaymentServiceProviderPort {
     }
 
     private void appendMerchantAccount(final StringBuilder buffer, final String merchantAccount) {
-        buffer.append("merchantAccount='").append(merchantAccount).append("'");
+        buffer.append(", merchantAccount='").append(merchantAccount).append("'");
     }
 
     private void appendPaymentData(final StringBuilder buffer, final PaymentData paymentData) {

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/BaseAdyenPaymentServiceProviderPort.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/BaseAdyenPaymentServiceProviderPort.java
@@ -44,7 +44,7 @@ public abstract class BaseAdyenPaymentServiceProviderPort {
         logger.info(logBuffer.toString());
     }
 
-    protected void logTransaction(final String transactionType, final String pspReference, String merchantAccount, final PaymentData paymentData, final PaymentModificationResponse response, final AdyenCallResult<?> adyenCall) {
+    protected void logTransaction(final String transactionType, final String pspReference, final String merchantAccount, final PaymentData paymentData, final PaymentModificationResponse response, final AdyenCallResult<?> adyenCall) {
         final StringBuilder logBuffer = new StringBuilder();
         appendTransactionType(logBuffer, transactionType);
         appendMerchantAccount(logBuffer, merchantAccount);
@@ -57,7 +57,7 @@ public abstract class BaseAdyenPaymentServiceProviderPort {
         logger.info(logBuffer.toString());
     }
 
-    protected void logTransactionError(final String transactionType, final UserData userData, String merchantAccount, final PaymentData paymentData, final AdyenCallResult<?> adyenCall) {
+    protected void logTransactionError(final String transactionType, final UserData userData, final String merchantAccount, final PaymentData paymentData, final AdyenCallResult<?> adyenCall) {
         final StringBuilder logBuffer = new StringBuilder();
         appendTransactionType(logBuffer, transactionType);
         appendMerchantAccount(logBuffer, merchantAccount);
@@ -69,11 +69,10 @@ public abstract class BaseAdyenPaymentServiceProviderPort {
         logger.info(logBuffer.toString());
     }
 
-    protected void logTransactionError(final String transactionType, final String pspReference, String merchantAccount, final PaymentData paymentData, final AdyenCallResult<?> adyenCall) {
+    protected void logTransactionError(final String transactionType, final String pspReference, final String merchantAccount, final PaymentData paymentData, final AdyenCallResult<?> adyenCall) {
         final StringBuilder logBuffer = new StringBuilder();
         appendTransactionType(logBuffer, transactionType);
         appendMerchantAccount(logBuffer, merchantAccount);
-        appendPspReference(logBuffer, pspReference);
         appendPaymentData(logBuffer, paymentData);
         appendPspReference(logBuffer, pspReference);
         appendAdyenCall(logBuffer, adyenCall);
@@ -100,9 +99,9 @@ public abstract class BaseAdyenPaymentServiceProviderPort {
                   .append(paymentData.getAmount())
                   .append("'");
         }
-        if (paymentData.getAmount() != null) {
-            buffer.append(", amount='")
-                  .append(paymentData.getAmount())
+        if (paymentData.getCurrency() != null) {
+            buffer.append(", currency='")
+                  .append(paymentData.getCurrency())
                   .append("'");
         }
         if (paymentData.getPaymentTransactionExternalKey() != null) {
@@ -114,7 +113,7 @@ public abstract class BaseAdyenPaymentServiceProviderPort {
 
     private void appendUserData(final StringBuilder buffer, final UserData userData) {
         if (userData != null && userData.getShopperReference() != null) {
-            buffer.append(", customerId='")
+            buffer.append(", shopperReference='")
                   .append(userData.getShopperReference())
                   .append("'");
         }

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/BaseAdyenPaymentServiceProviderPort.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/BaseAdyenPaymentServiceProviderPort.java
@@ -66,7 +66,7 @@ public abstract class BaseAdyenPaymentServiceProviderPort {
         appendAdyenCall(logBuffer, adyenCall);
         logBuffer.append(", error=true");
 
-        logger.info(logBuffer.toString());
+        logger.warn(logBuffer.toString());
     }
 
     protected void logTransactionError(final String transactionType, final String pspReference, final String merchantAccount, final PaymentData paymentData, final AdyenCallResult<?> adyenCall) {
@@ -78,7 +78,7 @@ public abstract class BaseAdyenPaymentServiceProviderPort {
         appendAdyenCall(logBuffer, adyenCall);
         logBuffer.append(", error=true");
 
-        logger.info(logBuffer.toString());
+        logger.warn(logBuffer.toString());
     }
 
     private void appendTransactionType(final StringBuilder buffer, final String transactionType) {

--- a/src/test/java/org/killbill/billing/plugin/adyen/client/jaxws/TestLoggingOutInterceptor.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/client/jaxws/TestLoggingOutInterceptor.java
@@ -34,6 +34,14 @@ public class TestLoggingOutInterceptor {
     }
 
     @Test
+    public void testAuthenticationHeaderObfuscation() {
+        final String authScheme = "Basic d3NGFueKYWRlx3NDApMjM=";
+        final String result = new LoggingOutInterceptor().transform(" Headers: {Accept=[*/*], Authorization=["+ authScheme + "] ");
+
+        Assert.assertFalse(result.contains(authScheme));
+    }
+
+    @Test
     public void testPayUExpiryMonthObfuscation() {
         final String month = "04";
 


### PR DESCRIPTION
Adds latency to log entries, only logging one event per transaction (with an error flag attribute included).

Also refactors a bit the notification handling code, also adding latency to log entries.

Here are a few examples of log entries for Transaction Operations:
```bash
# Hpp
op='createHppRequest', merchantAccount='MyCityDealDE', amount='10', amount='10', paymentTransactionExternalKey='fd623240-262f-4f0c-b32f-22f5e6f25199', error=false

# Payments
op='authorize', merchantAccount='MyCityDealDE', amount='10', amount='10', paymentTransactionExternalKey='eb5859d2-3691-4b63-b504-7f7c7a820526', PurchaseResult{result='Authorised', authCode='75613', pspReference='8814725091152670', reason='null', resultCode='Authorised', reference='null', paymentTransactionExternalKey='eb5859d2-3691-4b63-b504-7f7c7a820526', adyenCallErrorStatus=null, additionalData={authCode='75613', refusalReasonRaw='AUTHORISED', avsResult='5 No AVS data provided', avsResultRaw='5', acquirerReference='7F54NDV1I6P', cvcResult='1 Matches', cvcResultRaw='1', acquirerCode='TestPmmAcquirer'}}, duration=3024, error=false
op='cancel', merchantAccount='MyCityDealDE', pspReference='1a24b4f3-a4b5-4ddc-9bd4-16dcdec207fd', paymentTransactionExternalKey='d3fae27a-eeb3-4baa-ba5b-02be55ec8ce4', pspReference='1a24b4f3-a4b5-4ddc-9bd4-16dcdec207fd', UnSuccessfulAdyenCall{responseStatus=RESPONSE_INVALID, exceptionMessage='HTTP response '422: Unprocessable Entity' when communicating with https://pal-test.adyen.com/pal/servlet/Payment/v12', exceptionClass='org.apache.cxf.transport.http.HTTPException', duration=176 }, error=true

op='authorize', merchantAccount='MyCityDealDE', amount='10', amount='10', paymentTransactionExternalKey='2485f71c-1cfa-4baf-ba24-cf09c6732954', PurchaseResult{result='Authorised', authCode='23053', pspReference='8514725091166343', reason='null', resultCode='Authorised', reference='null', paymentTransactionExternalKey='2485f71c-1cfa-4baf-ba24-cf09c6732954', adyenCallErrorStatus=null, additionalData={authCode='23053', refusalReasonRaw='AUTHORISED', avsResult='5 No AVS data provided', avsResultRaw='5', acquirerReference='7CA6B5NDF1P', cvcResult='1 Matches', cvcResultRaw='1', acquirerCode='TestPmmAcquirer'}}, duration=965, error=false
op='capture', merchantAccount='MyCityDealDE', amount='5', amount='5', paymentTransactionExternalKey='75679349-688d-4f5c-b14c-e6f9f72e0519', pspReference='8514725091166343', PaymentModificationResponse{adyenCallErrorStatus=null, pspReference='8614725091175632', response='[capture-received]', additionalData={}}, duration=181, error=false
op='capture', merchantAccount='MyCityDealDE', amount='5', amount='5', paymentTransactionExternalKey='829e26a5-1592-440e-9fe7-4d861adaa718', pspReference='8514725091166343', PaymentModificationResponse{adyenCallErrorStatus=null, pspReference='8814725091172702', response='[capture-received]', additionalData={}}, duration=340, error=false

op='authorize', merchantAccount='MyCityDealDE', amount='10', amount='10', paymentTransactionExternalKey='8666c104-6738-49e2-8727-d727516717d2', PurchaseResult{result='Authorised', authCode='8047', pspReference='7914725091176134', reason='null', resultCode='Authorised', reference='null', paymentTransactionExternalKey='8666c104-6738-49e2-8727-d727516717d2', adyenCallErrorStatus=null, additionalData={authCode='8047', refusalReasonRaw='AUTHORISED', avsResult='5 No AVS data provided', avsResultRaw='5', acquirerReference='7F54NDV25OG', cvcResult='1 Matches', cvcResultRaw='1', acquirerCode='TestPmmAcquirer'}}, duration=525, error=false
op='cancel', merchantAccount='MyCityDealDE', paymentTransactionExternalKey='c5afe094-40bb-462e-a026-caecd1285300', pspReference='7914725091176134', PaymentModificationResponse{adyenCallErrorStatus=null, pspReference='8814725091182719', response='[cancel-received]', additionalData={}}, duration=183, error=false

op='authorize', merchantAccount='MyCityDealDE', amount='10', amount='10', paymentTransactionExternalKey='43854743-a134-47b3-984c-e8003622c298', PurchaseResult{result='Authorised', authCode='24385', pspReference='7914725091186141', reason='null', resultCode='Authorised', reference='null', paymentTransactionExternalKey='43854743-a134-47b3-984c-e8003622c298', adyenCallErrorStatus=null, additionalData={authCode='24385', refusalReasonRaw='AUTHORISED', avsResult='5 No AVS data provided', avsResultRaw='5', acquirerReference='7CA6B5NE2JH', cvcResult='1 Matches', cvcResultRaw='1', acquirerCode='TestPmmAcquirer'}}, duration=411, error=false
op='capture', merchantAccount='MyCityDealDE', amount='10', amount='10', paymentTransactionExternalKey='5f2dd36b-3c6d-4b59-ae03-05f138b7d0bc', pspReference='7914725091186141', PaymentModificationResponse{adyenCallErrorStatus=null, pspReference='8514725091186382', response='[capture-received]', additionalData={}}, duration=386, error=false
op='refund', merchantAccount='MyCityDealDE', amount='10', amount='10', paymentTransactionExternalKey='46552eef-55a0-4ebb-bd9e-e074fd34045b', pspReference='8514725091186382', PaymentModificationResponse{adyenCallErrorStatus=null, pspReference='8814725091192726', response='[refund-received]', additionalData={}}, duration=202, error=false
```

And here are some log entries for notification handling:
```bash
op='notificationHandling' eventCode='AUTHORISATION', pspReference='4823660019473428', originalReference='null', success='true', reason='111647:7629:5/2014', merchantReference='325147059', merchantAccount='TestMerchant', duration=4, error=false
op='notificationHandling' eventCode='NOTIFICATION_OF_CHARGEBACK', pspReference='4679660098811789', originalReference='1805647532335033', success='true', reason='2013.04.12/08.09.20/821', merchantReference='1-6GNEZHGTGT', merchantAccount='TestMerchant', duration=0, error=false
op='notificationHandling' eventCode='NOTIFICATION_OF_CHARGEBACK', pspReference='4894660098821804', originalReference='1329636226549589', success='true', reason='2013.04.12/08.18.50/821', merchantReference='1-AYA5VKUZDP', merchantAccount='TestMerchant', duration=0, error=false
op='notificationHandling' eventCode='NOTIFICATION_OF_CHARGEBACK', pspReference='5299660098821820', originalReference='4328641331002023', success='true', reason='2013.04.12/08.26.54/672', merchantReference='1-J6X6UXKG4A', merchantAccount='TestMerchant', duration=0, error=false
op='notificationHandling' eventCode='CHARGEBACK_REVERSED', pspReference='4815580881292917', originalReference='null', success='true', reason='Chargeback reversed', merchantReference='1-AWSSVULBWX', merchantAccount='TestMerchant', duration=0, error=false
```