### PR TITLE
Fixes X-Request-Id Interceptor

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/adyen/client/jaxws/HttpHeaderInterceptor.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/jaxws/HttpHeaderInterceptor.java
@@ -39,7 +39,7 @@ public class HttpHeaderInterceptor extends AbstractPhaseInterceptor<Message> {
     private static final String MDC_REQUEST_ID = "req.requestId";
 
     public HttpHeaderInterceptor() {
-        super(Phase.POST_PROTOCOL);
+        super(Phase.PRE_STREAM);
     }
 
     @Override

--- a/src/test/java/org/killbill/billing/plugin/adyen/client/jaxws/TestHttpHeaderInterceptor.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/client/jaxws/TestHttpHeaderInterceptor.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.cxf.message.Message;
+import org.apache.cxf.phase.Phase;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -30,6 +31,7 @@ public class TestHttpHeaderInterceptor {
     @Test(groups = "fast")
     public void testAddRequestId() throws Exception {
         final HttpHeaderInterceptor interceptor = new HttpHeaderInterceptor();
+        Assert.assertEquals(interceptor.getPhase(), Phase.PRE_STREAM);
 
         final Map<String, List<String>> headers = new HashMap<String, List<String>>();
         final Message message = Mockito.mock(Message.class);


### PR DESCRIPTION
Verified using a a local server:
```
{ ... "HTTP_X_REQUEST_ID"=>"3b446aad-e1dd-47cf-9727-3c146f48350b" ... }
127.0.0.1 - - [13/Oct/2016:18:21:55 PDT] "POST /pal/servlet/Payment/v12 HTTP/1.1" 200 21
```