### PR TITLE
Make sure the lastSuccessPaymentState field is populated

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/adyen/core/KillbillAdyenNotificationHandler.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/core/KillbillAdyenNotificationHandler.java
@@ -328,6 +328,7 @@ public class KillbillAdyenNotificationHandler implements AdyenNotificationHandle
         }
 
         final String currentPaymentStateName = String.format("%s_%s", updatedPaymentTransaction.getTransactionType() == TransactionType.AUTHORIZE ? "AUTH" : updatedPaymentTransaction.getTransactionType(), paymentPluginStatus == PaymentPluginStatus.PROCESSED ? "SUCCESS" : "FAILED");
+        final String lastSuccessfulPaymentStateName = paymentPluginStatus == PaymentPluginStatus.PROCESSED? currentPaymentStateName: null;
 
         final TransactionStatus transactionStatus;
         switch (paymentPluginStatus) {
@@ -351,7 +352,7 @@ public class KillbillAdyenNotificationHandler implements AdyenNotificationHandle
         logger.warn("Forcing transition paymentTransactionExternalKey='{}', oldPaymentPluginStatus='{}', newPaymentPluginStatus='{}'", updatedPaymentTransaction.getExternalKey(), updatedPaymentTransaction.getPaymentInfoPlugin().getStatus(), paymentPluginStatus);
 
         try {
-            osgiKillbillAPI.getAdminPaymentApi().fixPaymentTransactionState(payment, updatedPaymentTransaction, transactionStatus, null, currentPaymentStateName, ImmutableList.<PluginProperty>of(), context);
+            osgiKillbillAPI.getAdminPaymentApi().fixPaymentTransactionState(payment, updatedPaymentTransaction, transactionStatus, lastSuccessfulPaymentStateName, currentPaymentStateName, ImmutableList.<PluginProperty>of(), context);
             final Payment fixedPayment = getPayment(payment.getId(), context);
             return filterForTransaction(fixedPayment, updatedPaymentTransaction.getId());
         } catch (final PaymentApiException e) {


### PR DESCRIPTION
This is more of a conversation starter. The current patch would fix any case where a transaction initially marked as failed is fixed to successful (last successful state becomes current state).

For other cases, we'd still have an issue when, for example, a successful refund is transitioned to failed. Right now (and this PR doesn't fix that), the last successful state would be REFUND_SUCCESS, instead of CAPTURE_SUCCESS (the real last successful state). It should be possible to fix this, but there a two points worth considering:

1. Is this actually a problem? Does having the last successful state being equal to `REFUND_SUCCESS` break anything?
2. If it needs fixing, is this the right place to do it?