### PR TITLE
Improve Pending Payment Expiration Logic

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentTransactionInfoPlugin.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentTransactionInfoPlugin.java
@@ -54,6 +54,8 @@ public class AdyenPaymentTransactionInfoPlugin extends PluginPaymentTransactionI
     private static final Pattern REFUSAL_REASON_PATTERN = Pattern.compile("([0-9]+)\\s*:\\s*(.*)");
     private static final String REFUSAL_REASON_RAW = "refusalReasonRaw";
 
+    private final Optional<AdyenResponsesRecord> adyenResponseRecord;
+
     public AdyenPaymentTransactionInfoPlugin(final UUID kbPaymentId,
                                              final UUID kbTransactionPaymentPaymentId,
                                              final TransactionType transactionType,
@@ -74,6 +76,7 @@ public class AdyenPaymentTransactionInfoPlugin extends PluginPaymentTransactionI
               utcNow,
               utcNow,
               PluginProperties.buildPluginProperties(purchaseResult.getFormParameter()));
+        adyenResponseRecord = Optional.absent();
     }
 
     public AdyenPaymentTransactionInfoPlugin(final UUID kbPaymentId,
@@ -97,6 +100,7 @@ public class AdyenPaymentTransactionInfoPlugin extends PluginPaymentTransactionI
               utcNow,
               utcNow,
               buildProperties(paymentModificationResponse.getAdditionalData()));
+        adyenResponseRecord = Optional.absent();
     }
 
     public AdyenPaymentTransactionInfoPlugin(final AdyenResponsesRecord record) {
@@ -113,6 +117,7 @@ public class AdyenPaymentTransactionInfoPlugin extends PluginPaymentTransactionI
               new DateTime(record.getCreatedDate(), DateTimeZone.UTC),
               new DateTime(record.getCreatedDate(), DateTimeZone.UTC),
               buildProperties(toMap(record.getAdditionalData())));
+        adyenResponseRecord = Optional.of(record);
     }
 
     @Override
@@ -132,6 +137,10 @@ public class AdyenPaymentTransactionInfoPlugin extends PluginPaymentTransactionI
         }
 
         return null;
+    }
+
+    public Optional<AdyenResponsesRecord> getAdyenResponseRecord() {
+        return adyenResponseRecord;
     }
 
     private static String getGatewayError(final PurchaseResult purchaseResult) {

--- a/src/main/java/org/killbill/billing/plugin/adyen/api/ExpiredPaymentPolicy.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/api/ExpiredPaymentPolicy.java
@@ -73,14 +73,20 @@ public class ExpiredPaymentPolicy {
         return true;
     }
 
-    private DateTime expirationDate(AdyenPaymentTransactionInfoPlugin transaction) {
-        if (transaction.getAdyenResponseRecord().isPresent()) {
-            final AdyenResponsesRecord adyenResponsesRecord = transaction.getAdyenResponseRecord().get();
-            if (PaymentServiceProviderResult.REDIRECT_SHOPPER.toString().equals(adyenResponsesRecord.getResultCode())) {
-                return transaction.getCreatedDate().plusMinutes(adyenProperties.getPending3DsPaymentExpirationPeriod());
-            }
+    private DateTime expirationDate(final AdyenPaymentTransactionInfoPlugin transaction) {
+        if (is3ds(transaction)) {
+            return transaction.getCreatedDate().plus(adyenProperties.getPending3DsPaymentExpirationPeriod());
         }
 
-        return transaction.getCreatedDate().plusMinutes(adyenProperties.getPendingPaymentExpirationPeriod());
+        return transaction.getCreatedDate().plus(adyenProperties.getPendingPaymentExpirationPeriod());
+    }
+
+    private boolean is3ds(final AdyenPaymentTransactionInfoPlugin transaction) {
+        if (!transaction.getAdyenResponseRecord().isPresent()) {
+            return false;
+        }
+
+        final AdyenResponsesRecord adyenResponsesRecord = transaction.getAdyenResponseRecord().get();
+        return PaymentServiceProviderResult.REDIRECT_SHOPPER.toString().equals(adyenResponsesRecord.getResultCode());
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/AdyenConfigProperties.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/AdyenConfigProperties.java
@@ -28,7 +28,8 @@ public class AdyenConfigProperties {
 
     public static final String DEFAULT_HMAC_ALGORITHM = "HmacSHA256";
 
-    public static final int DEFAULT_PENDING_PAYMENT_EXPIRATION_PERIOD_IN_DAYS = 3;
+    public static final int DEFAULT_PENDING_PAYMENT_EXPIRATION_PERIOD = 3 * 24 * 60;
+    public static final int DEFAULT_PENDING_3DS_PAYMENT_EXPIRATION_PERIOD = 3 * 60;
 
     private static final String PROPERTY_PREFIX = "org.killbill.billing.plugin.adyen.";
     private static final String ENTRY_DELIMITER = "|";
@@ -65,7 +66,10 @@ public class AdyenConfigProperties {
     private final String acquirersList;
     private final String paymentConnectionTimeout;
     private final String paymentReadTimeout;
-    private final int pendingPaymentExpirationPeriodInDays;
+
+    private final int pendingPaymentExpirationPeriod;
+
+    private final int pending3DsPaymentExpirationPeriod;
 
     public AdyenConfigProperties(final Properties properties) {
         this.proxyServer = properties.getProperty(PROPERTY_PREFIX + "proxyServer");
@@ -88,14 +92,8 @@ public class AdyenConfigProperties {
         this.hppSkipDetailsTarget = this.hppTarget != null ? this.hppTarget.replace(this.hppTarget.substring(this.hppTarget.lastIndexOf('/') + 1), "skipDetails.shtml") : null;
         this.hppVariantOverride = properties.getProperty(PROPERTY_PREFIX + "hppVariantOverride");
 
-        int pendingPaymentExpirationPeriodInDays = 0;
-        try {
-            final String pendingPaymentExpirationPeriod = properties.getProperty(PROPERTY_PREFIX + "pendingPaymentExpirationPeriodInDays");
-            pendingPaymentExpirationPeriodInDays = Integer.parseInt(pendingPaymentExpirationPeriod);
-        } catch(NumberFormatException e) {
-            pendingPaymentExpirationPeriodInDays = DEFAULT_PENDING_PAYMENT_EXPIRATION_PERIOD_IN_DAYS;
-        }
-        this.pendingPaymentExpirationPeriodInDays = pendingPaymentExpirationPeriodInDays;
+        this.pendingPaymentExpirationPeriod = readPendingExpirationProperty(properties);
+        this.pending3DsPaymentExpirationPeriod = read3DsPendingExpirationProperty(properties);
 
         this.acquirersList = properties.getProperty(PROPERTY_PREFIX + "acquirersList");
 
@@ -151,6 +149,36 @@ public class AdyenConfigProperties {
             final String secretAlgorithm = countryOrSkinToSecretAlgorithmMap.get(countryOrSkin);
             skinToSecretAlgorithmMap.put(skin, secretAlgorithm);
         }
+    }
+
+    private int readPendingExpirationProperty(final Properties properties) {
+        final String valueInDays = properties.getProperty(PROPERTY_PREFIX + "pendingPaymentExpirationPeriodInDays");
+        if (valueInDays != null) {
+            try {
+                return Integer.parseInt(valueInDays) * 24 * 60;
+            } catch (NumberFormatException e) { /* Ignore */ }
+        }
+
+        final String value = properties.getProperty(PROPERTY_PREFIX + "pendingPaymentExpirationPeriod");
+        if (value != null) {
+            return Integer.parseInt(value);
+        }
+        return DEFAULT_PENDING_PAYMENT_EXPIRATION_PERIOD;
+    }
+
+    private int read3DsPendingExpirationProperty(final Properties properties) {
+        final String valueInDays = properties.getProperty(PROPERTY_PREFIX + "pending3DsPaymentExpirationPeriodInDays");
+        if (valueInDays != null) {
+            try {
+                return Integer.parseInt(valueInDays) * 24 * 60;
+            } catch (NumberFormatException e) { /* Ignore */ }
+        }
+
+        final String value = properties.getProperty(PROPERTY_PREFIX + "pending3DsPaymentExpirationPeriod");
+        if (value != null) {
+            return Integer.parseInt(value);
+        }
+        return DEFAULT_PENDING_3DS_PAYMENT_EXPIRATION_PERIOD;
     }
 
     public String getMerchantAccount(final String countryIsoCode) {
@@ -216,8 +244,12 @@ public class AdyenConfigProperties {
         return hppVariantOverride;
     }
 
-    public int getPendingPaymentExpirationPeriodInDays() {
-        return pendingPaymentExpirationPeriodInDays;
+    public int getPendingPaymentExpirationPeriod() {
+        return pendingPaymentExpirationPeriod;
+    }
+
+    public int getPending3DsPaymentExpirationPeriod() {
+        return pending3DsPaymentExpirationPeriod;
     }
 
     public String getAcquirersList() {

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/AdyenConfigProperties.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/AdyenConfigProperties.java
@@ -161,7 +161,9 @@ public class AdyenConfigProperties {
 
         final String value = properties.getProperty(PROPERTY_PREFIX + "pendingPaymentExpirationPeriod");
         if (value != null) {
-            return Integer.parseInt(value);
+            try {
+                return Integer.parseInt(value);
+            } catch (NumberFormatException e) { /* Ignore */ }
         }
         return DEFAULT_PENDING_PAYMENT_EXPIRATION_PERIOD;
     }
@@ -176,7 +178,9 @@ public class AdyenConfigProperties {
 
         final String value = properties.getProperty(PROPERTY_PREFIX + "pending3DsPaymentExpirationPeriod");
         if (value != null) {
-            return Integer.parseInt(value);
+            try {
+                return Integer.parseInt(value);
+            } catch (NumberFormatException e) { /* Ignore */ }
         }
         return DEFAULT_PENDING_3DS_PAYMENT_EXPIRATION_PERIOD;
     }

--- a/src/test/java/org/killbill/billing/plugin/adyen/api/TestAdyenPaymentPluginApi.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/api/TestAdyenPaymentPluginApi.java
@@ -474,7 +474,7 @@ public class TestAdyenPaymentPluginApi extends TestAdyenPaymentPluginApiBase {
                                                                                                              context);
         assertEquals(authorizationInfoPlugin.getStatus(), PaymentPluginStatus.PENDING);
 
-        final Period expirationPeriod = Period.days(adyenConfigProperties.getPendingPaymentExpirationPeriodInDays()).plusMinutes(1);
+        final Period expirationPeriod = Period.minutes(adyenConfigProperties.getPending3DsPaymentExpirationPeriod()).plusMinutes(1);
         clock.setDeltaFromReality(expirationPeriod.toStandardDuration().getMillis());
 
         final List<PaymentTransactionInfoPlugin> expiredPaymentTransactions = adyenPaymentPluginApi.getPaymentInfo(account.getId(),

--- a/src/test/java/org/killbill/billing/plugin/adyen/api/TestAdyenPaymentPluginApi.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/api/TestAdyenPaymentPluginApi.java
@@ -474,7 +474,7 @@ public class TestAdyenPaymentPluginApi extends TestAdyenPaymentPluginApiBase {
                                                                                                              context);
         assertEquals(authorizationInfoPlugin.getStatus(), PaymentPluginStatus.PENDING);
 
-        final Period expirationPeriod = Period.minutes(adyenConfigProperties.getPending3DsPaymentExpirationPeriod()).plusMinutes(1);
+        final Period expirationPeriod = adyenConfigProperties.getPending3DsPaymentExpirationPeriod().plusMinutes(1);
         clock.setDeltaFromReality(expirationPeriod.toStandardDuration().getMillis());
 
         final List<PaymentTransactionInfoPlugin> expiredPaymentTransactions = adyenPaymentPluginApi.getPaymentInfo(account.getId(),

--- a/src/test/java/org/killbill/billing/plugin/adyen/api/TestAdyenPaymentPluginApiHPP.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/api/TestAdyenPaymentPluginApiHPP.java
@@ -101,7 +101,7 @@ public class TestAdyenPaymentPluginApiHPP extends TestAdyenPaymentPluginApiBase 
         final Payment payment = triggerBuildFormDescriptor(ImmutableMap.<String, String>of(AdyenPaymentPluginApi.PROPERTY_CREATE_PENDING_PAYMENT, "true",
                                                                                            AdyenPaymentPluginApi.PROPERTY_AUTH_MODE, "true"),
                                                            TransactionType.AUTHORIZE);
-        final Period expirationPeriod = Period.days(adyenConfigProperties.getPendingPaymentExpirationPeriodInDays()).plusMinutes(1);
+        final Period expirationPeriod = Period.minutes(adyenConfigProperties.getPendingPaymentExpirationPeriod()).plusMinutes(1);
         clock.setDeltaFromReality(expirationPeriod.toStandardDuration().getMillis());
 
         final List<PaymentTransactionInfoPlugin> transactions = adyenPaymentPluginApi.getPaymentInfo(account.getId(), payment.getId(), Collections.<PluginProperty>emptyList(), context);

--- a/src/test/java/org/killbill/billing/plugin/adyen/api/TestAdyenPaymentPluginApiHPP.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/api/TestAdyenPaymentPluginApiHPP.java
@@ -101,7 +101,7 @@ public class TestAdyenPaymentPluginApiHPP extends TestAdyenPaymentPluginApiBase 
         final Payment payment = triggerBuildFormDescriptor(ImmutableMap.<String, String>of(AdyenPaymentPluginApi.PROPERTY_CREATE_PENDING_PAYMENT, "true",
                                                                                            AdyenPaymentPluginApi.PROPERTY_AUTH_MODE, "true"),
                                                            TransactionType.AUTHORIZE);
-        final Period expirationPeriod = Period.minutes(adyenConfigProperties.getPendingPaymentExpirationPeriod()).plusMinutes(1);
+        final Period expirationPeriod = adyenConfigProperties.getPendingPaymentExpirationPeriod().plusMinutes(1);
         clock.setDeltaFromReality(expirationPeriod.toStandardDuration().getMillis());
 
         final List<PaymentTransactionInfoPlugin> transactions = adyenPaymentPluginApi.getPaymentInfo(account.getId(), payment.getId(), Collections.<PluginProperty>emptyList(), context);


### PR DESCRIPTION
Add expiration period property for pending 3DS payments

WIP: Change payment status to failed when we receive a CANCELED (or something equivalent) authResult parameter value in the complete call.