### PR TITLE
Return null for non-numeric error code

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentTransactionInfoPlugin.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentTransactionInfoPlugin.java
@@ -170,17 +170,15 @@ public class AdyenPaymentTransactionInfoPlugin extends PluginPaymentTransactionI
     }
 
     private static String getGatewayError(final AdyenResponsesRecord record) {
-        final String errorMessage;
         final Map additionalData = AdyenDao.fromAdditionalData(record.getAdditionalData());
         final String refusalResponseMessage = getGatewayError(additionalData);
         if (refusalResponseMessage != null) {
-            errorMessage = refusalResponseMessage;
+            return formatErrorMessage(refusalResponseMessage);
         } else if (record.getRefusalReason() != null) {
-            errorMessage = record.getRefusalReason();
+            return formatErrorMessage(record.getRefusalReason());
         } else {
-            errorMessage = toString(additionalData.get(PurchaseResult.EXCEPTION_MESSAGE));
+            return toString(additionalData.get(PurchaseResult.EXCEPTION_MESSAGE));
         }
-        return formatErrorMessage(errorMessage);
     }
 
     private static String getGatewayError(@Nullable final Map additionalData) {
@@ -203,40 +201,15 @@ public class AdyenPaymentTransactionInfoPlugin extends PluginPaymentTransactionI
     }
 
     private static String getGatewayErrorCode(final PurchaseResult purchaseResult) {
-        final String refusalResponseCode = getGatewayErrorCode(purchaseResult.getAdditionalData());
-        if (refusalResponseCode != null) {
-            return refusalResponseCode;
-        } else if (purchaseResult.getResultCode() != null) {
-            return purchaseResult.getResultCode();
-        } else {
-            return getExceptionClass(purchaseResult.getAdditionalData());
-        }
+        return getGatewayErrorCode(purchaseResult.getAdditionalData());
     }
 
     private static String getGatewayErrorCode(final PaymentModificationResponse paymentModificationResponse) {
-        final String refusalResponseCode = getGatewayErrorCode(paymentModificationResponse.getAdditionalData());
-        if (refusalResponseCode != null) {
-            return refusalResponseCode;
-        } else if (paymentModificationResponse.getResponse() != null) {
-            return paymentModificationResponse.getResponse();
-        } else {
-            return getExceptionClass(paymentModificationResponse.getAdditionalData());
-        }
+        return getGatewayErrorCode(paymentModificationResponse.getAdditionalData());
     }
 
     private static String getGatewayErrorCode(final AdyenResponsesRecord record) {
-        final Map additionalData = AdyenDao.fromAdditionalData(record.getAdditionalData());
-        final String refusalResponseCode = getGatewayErrorCode(additionalData);
-        if (refusalResponseCode != null) {
-            return refusalResponseCode;
-        } else if (record.getResultCode() != null) {
-            return record.getResultCode();
-        } else if (record.getPspResult() != null) {
-            // PaymentModificationResponse
-            return record.getPspResult();
-        } else {
-            return getExceptionClass(additionalData);
-        }
+        return getGatewayErrorCode(AdyenDao.fromAdditionalData(record.getAdditionalData()));
     }
 
     private static String getGatewayErrorCode(@Nullable final Map additionalData) {

--- a/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentTransactionInfoPlugin.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentTransactionInfoPlugin.java
@@ -173,9 +173,9 @@ public class AdyenPaymentTransactionInfoPlugin extends PluginPaymentTransactionI
         final Map additionalData = AdyenDao.fromAdditionalData(record.getAdditionalData());
         final String refusalResponseMessage = getGatewayError(additionalData);
         if (refusalResponseMessage != null) {
-            return formatErrorMessage(refusalResponseMessage);
+            return refusalResponseMessage;
         } else if (record.getRefusalReason() != null) {
-            return formatErrorMessage(record.getRefusalReason());
+            return record.getRefusalReason();
         } else {
             return toString(additionalData.get(PurchaseResult.EXCEPTION_MESSAGE));
         }
@@ -411,14 +411,5 @@ public class AdyenPaymentTransactionInfoPlugin extends PluginPaymentTransactionI
 
         final Iterable<PluginProperty> propertiesWithDefaults = PluginProperties.merge(defaultProperties, originalProperties);
         return ImmutableList.<PluginProperty>copyOf(propertiesWithDefaults);
-    }
-
-    @VisibleForTesting
-    static String formatErrorMessage(final String gatewayError) {
-        if(Strings.isNullOrEmpty(gatewayError)) {
-            return gatewayError;
-        }
-        //Remove any extra spaces between word and convert all to lower-case
-        return gatewayError.replaceAll("\\s+", " ").trim().toLowerCase();
     }
 }

--- a/src/test/java/org/killbill/billing/plugin/adyen/api/TestAdyenPaymentTransactionInfoPlugin.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/api/TestAdyenPaymentTransactionInfoPlugin.java
@@ -60,8 +60,7 @@ public class TestAdyenPaymentTransactionInfoPlugin {
                                                                               new Timestamp(1242L),
                                                                               UUID.randomUUID().toString());
         final PaymentTransactionInfoPlugin paymentTransactionInfoPlugin = new AdyenPaymentTransactionInfoPlugin(responsesRecord);
-        Assert.assertEquals(paymentTransactionInfoPlugin.getGatewayErrorCode(), "configuration 905 Payment detail");
-        Assert.assertEquals(paymentTransactionInfoPlugin.getGatewayErrorCode().length(), 32);
+        Assert.assertNull(paymentTransactionInfoPlugin.getGatewayErrorCode());
     }
 
     @Test(groups = "fast")
@@ -94,6 +93,38 @@ public class TestAdyenPaymentTransactionInfoPlugin {
         final PaymentTransactionInfoPlugin paymentTransactionInfoPlugin = new AdyenPaymentTransactionInfoPlugin(responsesRecord);
         Assert.assertEquals(paymentTransactionInfoPlugin.getGatewayError(), "do not honor");
         Assert.assertEquals(paymentTransactionInfoPlugin.getGatewayErrorCode(), "05");
+    }
+
+    @Test(groups = "fast")
+    public void testNullGatewayErrorCode() throws Exception {
+        final AdyenResponsesRecord responsesRecord = new AdyenResponsesRecord(UInteger.valueOf(1),
+                                                                              UUID.randomUUID().toString(),
+                                                                              UUID.randomUUID().toString(),
+                                                                              UUID.randomUUID().toString(),
+                                                                              TransactionType.AUTHORIZE.toString(),
+                                                                              BigDecimal.TEN,
+                                                                              Currency.USD.toString(),
+                                                                              null,
+                                                                              UUID.randomUUID().toString(),
+                                                                              UUID.randomUUID().toString(),
+                                                                              UUID.randomUUID().toString(),
+                                                                              "Not enough balance",
+                                                                              UUID.randomUUID().toString(),
+                                                                              UUID.randomUUID().toString(),
+                                                                              UUID.randomUUID().toString(),
+                                                                              UUID.randomUUID().toString(),
+                                                                              BigDecimal.ZERO,
+                                                                              Currency.USD.toString(),
+                                                                              UUID.randomUUID().toString(),
+                                                                              UUID.randomUUID().toString(),
+                                                                              UUID.randomUUID().toString(),
+                                                                              UUID.randomUUID().toString(),
+                                                                              "{\"refusalReasonRaw\":\"ill-formatted raw refusal reason\"}",
+                                                                              new Timestamp(1242L),
+                                                                              UUID.randomUUID().toString());
+        final PaymentTransactionInfoPlugin paymentTransactionInfoPlugin = new AdyenPaymentTransactionInfoPlugin(responsesRecord);
+        Assert.assertEquals(paymentTransactionInfoPlugin.getGatewayError(), "not enough balance");
+        Assert.assertNull(paymentTransactionInfoPlugin.getGatewayErrorCode());
     }
 
     @Test(groups = "fast")

--- a/src/test/java/org/killbill/billing/plugin/adyen/api/TestAdyenPaymentTransactionInfoPlugin.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/api/TestAdyenPaymentTransactionInfoPlugin.java
@@ -91,7 +91,7 @@ public class TestAdyenPaymentTransactionInfoPlugin {
                                                                               new Timestamp(1242L),
                                                                               UUID.randomUUID().toString());
         final PaymentTransactionInfoPlugin paymentTransactionInfoPlugin = new AdyenPaymentTransactionInfoPlugin(responsesRecord);
-        Assert.assertEquals(paymentTransactionInfoPlugin.getGatewayError(), "do not honor");
+        Assert.assertEquals(paymentTransactionInfoPlugin.getGatewayError(), "Do not honor");
         Assert.assertEquals(paymentTransactionInfoPlugin.getGatewayErrorCode(), "05");
     }
 
@@ -123,15 +123,7 @@ public class TestAdyenPaymentTransactionInfoPlugin {
                                                                               new Timestamp(1242L),
                                                                               UUID.randomUUID().toString());
         final PaymentTransactionInfoPlugin paymentTransactionInfoPlugin = new AdyenPaymentTransactionInfoPlugin(responsesRecord);
-        Assert.assertEquals(paymentTransactionInfoPlugin.getGatewayError(), "not enough balance");
+        Assert.assertEquals(paymentTransactionInfoPlugin.getGatewayError(), "Not enough balance");
         Assert.assertNull(paymentTransactionInfoPlugin.getGatewayErrorCode());
-    }
-
-    @Test(groups = "fast")
-    public void testGatewayErrorFormat() {
-        Assert.assertEquals("fraud reject",
-                            AdyenPaymentTransactionInfoPlugin.formatErrorMessage(" FRAUD reject"));
-        Assert.assertEquals("not supported",
-                            AdyenPaymentTransactionInfoPlugin.formatErrorMessage(" NOT  Supported "));
     }
 }

--- a/src/test/java/org/killbill/billing/plugin/adyen/api/TestAdyenPaymentTransactionInfoPlugin.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/api/TestAdyenPaymentTransactionInfoPlugin.java
@@ -92,7 +92,15 @@ public class TestAdyenPaymentTransactionInfoPlugin {
                                                                               new Timestamp(1242L),
                                                                               UUID.randomUUID().toString());
         final PaymentTransactionInfoPlugin paymentTransactionInfoPlugin = new AdyenPaymentTransactionInfoPlugin(responsesRecord);
-        Assert.assertEquals(paymentTransactionInfoPlugin.getGatewayError(), "Do not honor");
+        Assert.assertEquals(paymentTransactionInfoPlugin.getGatewayError(), "do not honor");
         Assert.assertEquals(paymentTransactionInfoPlugin.getGatewayErrorCode(), "05");
+    }
+
+    @Test(groups = "fast")
+    public void testGatewayErrorFormat() {
+        Assert.assertEquals("fraud reject",
+                            AdyenPaymentTransactionInfoPlugin.formatErrorMessage(" FRAUD reject"));
+        Assert.assertEquals("not supported",
+                            AdyenPaymentTransactionInfoPlugin.formatErrorMessage(" NOT  Supported "));
     }
 }


### PR DESCRIPTION
@pierre As discussed offline, this PR will 1) return `null` if there isn't any numeric error code found; 2) format the error message except exceptions.