### PR TITLE
notifications: add option to transform CHARGEBACK into payment failure

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/adyen/client/AdyenConfigProperties.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/AdyenConfigProperties.java
@@ -23,6 +23,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 
@@ -31,6 +32,7 @@ import org.joda.time.Period;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class AdyenConfigProperties {
 
@@ -99,6 +101,7 @@ public class AdyenConfigProperties {
     private final String currentRegion;
 
     private final String invoicePaymentEnabled;
+    private final Set<String> chargebackAsFailurePaymentMethods;
 
     public AdyenConfigProperties(final Properties properties) {
         this(properties, null);
@@ -108,6 +111,7 @@ public class AdyenConfigProperties {
         this.currentRegion = currentRegion;
 
         this.invoicePaymentEnabled = properties.getProperty(PROPERTY_PREFIX + "invoicePaymentEnabled", "false");
+        this.chargebackAsFailurePaymentMethods = ImmutableSet.<String>copyOf(properties.getProperty(PROPERTY_PREFIX + "chargebackAsFailurePaymentMethods", "").split(","));
 
         this.proxyServer = properties.getProperty(PROPERTY_PREFIX + "proxyServer");
         this.proxyPort = properties.getProperty(PROPERTY_PREFIX + "proxyPort");
@@ -249,6 +253,10 @@ public class AdyenConfigProperties {
 
     public Boolean getInvoicePaymentEnabled() {
         return Boolean.valueOf(invoicePaymentEnabled);
+    }
+
+    public Set<String> getChargebackAsFailurePaymentMethods() {
+        return chargebackAsFailurePaymentMethods;
     }
 
     public String getMerchantAccount(final String countryIsoCode) {

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/model/NotificationItem.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/model/NotificationItem.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2014 Groupon, Inc
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
- * Groupon licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *
@@ -63,6 +64,34 @@ public class NotificationItem {
         this.pspReference = notificationRequestItem.getPspReference();
         this.reason = notificationRequestItem.getReason();
         this.success = notificationRequestItem.isSuccess();
+    }
+
+    public NotificationItem(final Map additionalData,
+                            final BigDecimal amount,
+                            final String currency,
+                            final String eventCode,
+                            final DateTime eventDate,
+                            final String merchantAccountCode,
+                            final String merchantReference,
+                            final List<String> operations,
+                            final String originalReference,
+                            final String paymentMethod,
+                            final String pspReference,
+                            final String reason,
+                            final Boolean success) {
+        this.additionalData = additionalData;
+        this.amount = amount;
+        this.currency = currency;
+        this.eventCode = eventCode;
+        this.eventDate = eventDate;
+        this.merchantAccountCode = merchantAccountCode;
+        this.merchantReference = merchantReference;
+        this.operations = operations;
+        this.originalReference = originalReference;
+        this.paymentMethod = paymentMethod;
+        this.pspReference = pspReference;
+        this.reason = reason;
+        this.success = success;
     }
 
     public Map getAdditionalData() {

--- a/src/test/java/org/killbill/billing/plugin/adyen/TestRemoteBase.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/TestRemoteBase.java
@@ -17,12 +17,10 @@
 
 package org.killbill.billing.plugin.adyen;
 
-import java.io.IOException;
 import java.util.Properties;
 
 import org.killbill.billing.account.api.Account;
 import org.killbill.billing.catalog.api.Currency;
-import org.killbill.billing.osgi.libs.killbill.OSGIConfigPropertiesService;
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillAPI;
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillLogService;
 import org.killbill.billing.plugin.TestUtils;
@@ -46,7 +44,6 @@ import org.killbill.billing.plugin.adyen.core.AdyenConfigPropertiesConfiguration
 import org.killbill.billing.plugin.adyen.core.AdyenConfigurationHandler;
 import org.killbill.billing.plugin.adyen.core.AdyenHostedPaymentPageConfigurationHandler;
 import org.killbill.billing.plugin.adyen.core.AdyenRecurringConfigurationHandler;
-import org.mockito.Mockito;
 import org.testng.annotations.BeforeClass;
 
 public abstract class TestRemoteBase {
@@ -87,9 +84,15 @@ public abstract class TestRemoteBase {
     protected AdyenPaymentServiceProviderPort adyenPaymentServiceProviderPort;
     protected AdyenPaymentServiceProviderHostedPaymentPagePort adyenPaymentServiceProviderHostedPaymentPagePort;
     protected AdyenRecurringClient adyenRecurringClient;
+    protected OSGIKillbillLogService logService;
 
     protected Properties properties;
     protected String merchantAccount;
+
+    @BeforeClass(groups = {"slow", "integration"})
+    public void setUpBeforeClassCommon() throws Exception {
+        logService = TestUtils.buildLogService();
+    }
 
     @BeforeClass(groups = "integration")
     public void setUpBeforeClass() throws Exception {
@@ -118,7 +121,6 @@ public abstract class TestRemoteBase {
 
         final Account account = TestUtils.buildAccount(Currency.BTC, "US");
         final OSGIKillbillAPI killbillAPI = TestUtils.buildOSGIKillbillAPI(account);
-        final OSGIKillbillLogService logService = TestUtils.buildLogService();
 
         adyenConfigurationHandler = new AdyenConfigurationHandler(AdyenActivator.PLUGIN_NAME, killbillAPI, logService, null);
         adyenConfigurationHandler.setDefaultConfigurable(adyenPaymentServiceProviderPort);
@@ -135,7 +137,7 @@ public abstract class TestRemoteBase {
         merchantAccount = adyenConfigProperties.getMerchantAccount(DEFAULT_COUNTRY);
     }
 
-    private AdyenConfigProperties getAdyenConfigProperties() throws IOException {
+    private AdyenConfigProperties getAdyenConfigProperties() {
         return new AdyenConfigProperties(properties);
     }
 }


### PR DESCRIPTION
To enable this feature, make sure to configure the per tenant property:

```
org.killbill.billing.plugin.adyen.chargebackAsFailurePaymentMethods=ach,sepadirectdebit
```

This fixes https://github.com/killbill/killbill-adyen-plugin/issues/79.

See related issue https://github.com/killbill/killbill/issues/880.
