### PR TITLE
Add sepa country code

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ Plugin properties
 | zip                      | Billing address zip code                      |
 | state                    | Billing address state                         |
 | country                  | Billing address country                       |
+| sepaCountryCode          | Billing address country code for SEPA requests. If absent, it will use country instead |
 | PaReq                    | 3D-Secure Pa Request                          |
 | PaRes                    | 3D-Secure Pa Response                         |
 | MD                       | 3D-Secure Message Digest                      |

--- a/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentPluginApi.java
@@ -151,7 +151,7 @@ public class AdyenPaymentPluginApi extends PluginPaymentPluginApi<AdyenResponses
     public static final String PROPERTY_DD_BANK_IDENTIFIER_CODE = "ddBic";
     // ELV only (processed as SEPA)
     public static final String PROPERTY_ELV_BLZ = "elvBlz";
-    public static final String PROPERTY_SPEA_COUNTRY_CODE = "sepaCountryCode";
+    public static final String PROPERTY_SEPA_COUNTRY_CODE = "sepaCountryCode";
 
     // User data
     public static final String PROPERTY_FIRST_NAME = "firstName";

--- a/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentPluginApi.java
@@ -151,6 +151,7 @@ public class AdyenPaymentPluginApi extends PluginPaymentPluginApi<AdyenResponses
     public static final String PROPERTY_DD_BANK_IDENTIFIER_CODE = "ddBic";
     // ELV only (processed as SEPA)
     public static final String PROPERTY_ELV_BLZ = "elvBlz";
+    public static final String PROPERTY_SPEA_COUNTRY_CODE = "sepaCountryCode";
 
     // User data
     public static final String PROPERTY_FIRST_NAME = "firstName";

--- a/src/main/java/org/killbill/billing/plugin/adyen/api/mapping/SepaDirectDebitMappingService.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/api/mapping/SepaDirectDebitMappingService.java
@@ -57,9 +57,12 @@ public abstract class SepaDirectDebitMappingService {
         final String ddHolderName = PluginProperties.getValue(PROPERTY_DD_HOLDER_NAME, paymentMethodHolderName, properties);
         sepaDirectDebit.setSepaAccountHolder(ddHolderName);
 
-        String countryCode = PluginProperties.getValue(PROPERTY_COUNTRY, paymentMethodsRecord.getCountry(), properties);
-        if (countryCode == null && account != null) {
-            countryCode = account.getCountry();
+        String countryCode = PluginProperties.findPluginPropertyValue("sepaCountryCode", properties);
+        if(countryCode == null) {
+            countryCode = PluginProperties.getValue(PROPERTY_COUNTRY, paymentMethodsRecord.getCountry(), properties);
+            if (countryCode == null && account != null) {
+                countryCode = account.getCountry();
+            }
         }
         sepaDirectDebit.setCountryCode(countryCode);
 

--- a/src/main/java/org/killbill/billing/plugin/adyen/api/mapping/SepaDirectDebitMappingService.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/api/mapping/SepaDirectDebitMappingService.java
@@ -30,7 +30,7 @@ import static org.killbill.billing.plugin.adyen.api.AdyenPaymentPluginApi.PROPER
 import static org.killbill.billing.plugin.adyen.api.AdyenPaymentPluginApi.PROPERTY_DD_BANK_IDENTIFIER_CODE;
 import static org.killbill.billing.plugin.adyen.api.AdyenPaymentPluginApi.PROPERTY_DD_HOLDER_NAME;
 import static org.killbill.billing.plugin.adyen.api.AdyenPaymentPluginApi.PROPERTY_ELV_BLZ;
-import static org.killbill.billing.plugin.adyen.api.AdyenPaymentPluginApi.PROPERTY_SPEA_COUNTRY_CODE;
+import static org.killbill.billing.plugin.adyen.api.AdyenPaymentPluginApi.PROPERTY_SEPA_COUNTRY_CODE;
 import static org.killbill.billing.plugin.api.payment.PluginPaymentPluginApi.PROPERTY_COUNTRY;
 
 public abstract class SepaDirectDebitMappingService {
@@ -58,7 +58,7 @@ public abstract class SepaDirectDebitMappingService {
         final String ddHolderName = PluginProperties.getValue(PROPERTY_DD_HOLDER_NAME, paymentMethodHolderName, properties);
         sepaDirectDebit.setSepaAccountHolder(ddHolderName);
 
-        String countryCode = PluginProperties.findPluginPropertyValue(PROPERTY_SPEA_COUNTRY_CODE, properties);
+        String countryCode = PluginProperties.findPluginPropertyValue(PROPERTY_SEPA_COUNTRY_CODE, properties);
         if(countryCode == null) {
             countryCode = PluginProperties.getValue(PROPERTY_COUNTRY, paymentMethodsRecord.getCountry(), properties);
             if (countryCode == null && account != null) {

--- a/src/main/java/org/killbill/billing/plugin/adyen/api/mapping/SepaDirectDebitMappingService.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/api/mapping/SepaDirectDebitMappingService.java
@@ -30,6 +30,7 @@ import static org.killbill.billing.plugin.adyen.api.AdyenPaymentPluginApi.PROPER
 import static org.killbill.billing.plugin.adyen.api.AdyenPaymentPluginApi.PROPERTY_DD_BANK_IDENTIFIER_CODE;
 import static org.killbill.billing.plugin.adyen.api.AdyenPaymentPluginApi.PROPERTY_DD_HOLDER_NAME;
 import static org.killbill.billing.plugin.adyen.api.AdyenPaymentPluginApi.PROPERTY_ELV_BLZ;
+import static org.killbill.billing.plugin.adyen.api.AdyenPaymentPluginApi.PROPERTY_SPEA_COUNTRY_CODE;
 import static org.killbill.billing.plugin.api.payment.PluginPaymentPluginApi.PROPERTY_COUNTRY;
 
 public abstract class SepaDirectDebitMappingService {
@@ -57,7 +58,7 @@ public abstract class SepaDirectDebitMappingService {
         final String ddHolderName = PluginProperties.getValue(PROPERTY_DD_HOLDER_NAME, paymentMethodHolderName, properties);
         sepaDirectDebit.setSepaAccountHolder(ddHolderName);
 
-        String countryCode = PluginProperties.findPluginPropertyValue("sepaCountryCode", properties);
+        String countryCode = PluginProperties.findPluginPropertyValue(PROPERTY_SPEA_COUNTRY_CODE, properties);
         if(countryCode == null) {
             countryCode = PluginProperties.getValue(PROPERTY_COUNTRY, paymentMethodsRecord.getCountry(), properties);
             if (countryCode == null && account != null) {

--- a/src/test/java/org/killbill/billing/plugin/adyen/api/mapping/SepaDirectDebitMappingServiceTest.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/api/mapping/SepaDirectDebitMappingServiceTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.plugin.adyen.api.mapping;
+
+import org.killbill.billing.account.api.AccountData;
+import org.killbill.billing.payment.api.PluginProperty;
+import org.killbill.billing.plugin.adyen.client.model.paymentinfo.SepaDirectDebit;
+import org.killbill.billing.plugin.adyen.dao.gen.tables.records.AdyenPaymentMethodsRecord;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SepaDirectDebitMappingServiceTest {
+
+    private AccountData accountData;
+    private AdyenPaymentMethodsRecord paymentMethodRecord;
+
+    @BeforeMethod(alwaysRun = true)
+    public void initialize() {
+        accountData = mock(AccountData.class);
+        paymentMethodRecord = mock(AdyenPaymentMethodsRecord.class);
+    }
+
+    @Test(groups = "fast")
+    public void testSepaMappingServiceWithSepaCountryCode() throws Exception {
+        SepaDirectDebit paymentInfo = SepaDirectDebitMappingService.toPaymentInfo(accountData, paymentMethodRecord,
+                                                                    ImmutableList.of(new PluginProperty("sepaCountryCode", "UK", false),
+                                                                                     new PluginProperty("country", "DE", false)));
+        Assert.assertEquals(paymentInfo.getCountryCode(), "UK");
+    }
+
+    @Test(groups = "fast")
+    public void testSepaMappingServiceWithoutSepaCountryCode() throws Exception {
+        SepaDirectDebit paymentInfo = SepaDirectDebitMappingService.toPaymentInfo(accountData, paymentMethodRecord,
+                                                                                  ImmutableList.of(new PluginProperty("country", "DE", false)));
+        Assert.assertEquals(paymentInfo.getCountryCode(), "DE");
+    }
+
+    @Test(groups = "fast")
+    public void testSepaMappingServiceWithoutAnyCountryCode() throws Exception {
+        when(paymentMethodRecord.getCountry()).thenReturn("DE");
+        SepaDirectDebit paymentInfo = SepaDirectDebitMappingService.toPaymentInfo(accountData, paymentMethodRecord, ImmutableList.of());
+        Assert.assertEquals(paymentInfo.getCountryCode(), "DE");
+    }
+
+    @Test(groups = "fast")
+    public void testSepaMappingServiceWithoutAnyCountryCodeAndPaymentMethod() throws Exception {
+        when(paymentMethodRecord.getCountry()).thenReturn(null);
+        when(accountData.getCountry()).thenReturn("DE");
+        SepaDirectDebit paymentInfo = SepaDirectDebitMappingService.toPaymentInfo(accountData, paymentMethodRecord, ImmutableList.of());
+        Assert.assertEquals(paymentInfo.getCountryCode(), "DE");
+    }
+
+}

--- a/src/test/java/org/killbill/billing/plugin/adyen/api/mapping/SepaDirectDebitMappingServiceTest.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/api/mapping/SepaDirectDebitMappingServiceTest.java
@@ -35,7 +35,7 @@ public class SepaDirectDebitMappingServiceTest {
     private AccountData accountData;
     private AdyenPaymentMethodsRecord paymentMethodRecord;
 
-    @BeforeMethod(alwaysRun = true)
+    @BeforeMethod(groups = "fast")
     public void initialize() {
         accountData = mock(AccountData.class);
         paymentMethodRecord = mock(AdyenPaymentMethodsRecord.class);


### PR DESCRIPTION
This is to allow sepa card can be routed to merchant accounts whose country code is different from the issuing country. cc @pierre for review.