### PR TITLE
api: add support for custom additionalData parameters

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/builder/AdyenRequestFactory.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/builder/AdyenRequestFactory.java
@@ -46,18 +46,18 @@ public class AdyenRequestFactory {
         this.signer = signer;
     }
 
-    public PaymentRequest createPaymentRequest(final String merchantAccount, final PaymentData paymentData, final UserData userData, @Nullable final SplitSettlementData splitSettlementData) {
-        final PaymentRequestBuilder paymentRequestBuilder = new PaymentRequestBuilder(merchantAccount, paymentData, userData, splitSettlementData, paymentInfoConverterManagement);
+    public PaymentRequest createPaymentRequest(final String merchantAccount, final PaymentData paymentData, final UserData userData, @Nullable final SplitSettlementData splitSettlementData, final Map<String, String> additionalData) {
+        final PaymentRequestBuilder paymentRequestBuilder = new PaymentRequestBuilder(merchantAccount, paymentData, userData, splitSettlementData, additionalData, paymentInfoConverterManagement);
         return paymentRequestBuilder.build();
     }
 
-    public PaymentRequest3D paymentRequest3d(final String merchantAccount, final PaymentData paymentData, final UserData userData, @Nullable final SplitSettlementData splitSettlementData) {
-        final PaymentRequest3DBuilder paymentRequest3DBuilder = new PaymentRequest3DBuilder(merchantAccount, paymentData, userData, splitSettlementData);
+    public PaymentRequest3D paymentRequest3d(final String merchantAccount, final PaymentData paymentData, final UserData userData, @Nullable final SplitSettlementData splitSettlementData, final Map<String, String> additionalData) {
+        final PaymentRequest3DBuilder paymentRequest3DBuilder = new PaymentRequest3DBuilder(merchantAccount, paymentData, userData, splitSettlementData, additionalData);
         return paymentRequest3DBuilder.build();
     }
 
-    public ModificationRequest createModificationRequest(final String merchantAccount, final PaymentData paymentData, final String pspReference, @Nullable final SplitSettlementData splitSettlementData) {
-        final ModificationRequestBuilder modificationRequestBuilder = new ModificationRequestBuilder(merchantAccount, paymentData, pspReference, splitSettlementData);
+    public ModificationRequest createModificationRequest(final String merchantAccount, final PaymentData paymentData, final String pspReference, @Nullable final SplitSettlementData splitSettlementData, final Map<String, String> additionalData) {
+        final ModificationRequestBuilder modificationRequestBuilder = new ModificationRequestBuilder(merchantAccount, paymentData, pspReference, splitSettlementData, additionalData);
         return modificationRequestBuilder.build();
     }
 

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/builder/ModificationRequestBuilder.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/builder/ModificationRequestBuilder.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014-2016 Groupon, Inc
- * Copyright 2014-2016 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -18,6 +18,7 @@
 package org.killbill.billing.plugin.adyen.client.payment.builder;
 
 import java.util.List;
+import java.util.Map;
 
 import javax.annotation.Nullable;
 
@@ -33,11 +34,13 @@ public class ModificationRequestBuilder extends RequestBuilder<ModificationReque
     private final PaymentData paymentData;
     private final String originalReference;
     private final SplitSettlementData splitSettlementData;
+    private final Map<String, String> additionalData;
 
     public ModificationRequestBuilder(final String merchantAccount,
                                       final PaymentData paymentData,
                                       final String originalReference,
-                                      @Nullable final SplitSettlementData splitSettlementData) {
+                                      @Nullable final SplitSettlementData splitSettlementData,
+                                      @Nullable final Map<String, String> additionalData) {
         super(new ModificationRequest());
         final AnyType2AnyTypeMap map = new AnyType2AnyTypeMap();
         request.setAdditionalData(map);
@@ -46,6 +49,7 @@ public class ModificationRequestBuilder extends RequestBuilder<ModificationReque
         this.paymentData = paymentData;
         this.originalReference = originalReference;
         this.splitSettlementData = splitSettlementData;
+        this.additionalData = additionalData;
     }
 
     @Override
@@ -56,6 +60,7 @@ public class ModificationRequestBuilder extends RequestBuilder<ModificationReque
 
         setAmount();
         setSplitSettlementData();
+        addAdditionalData(request.getAdditionalData(), additionalData);
 
         return request;
     }

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/builder/PaymentRequest3DBuilder.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/builder/PaymentRequest3DBuilder.java
@@ -18,6 +18,7 @@
 package org.killbill.billing.plugin.adyen.client.payment.builder;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import javax.annotation.Nullable;
@@ -43,11 +44,13 @@ public class PaymentRequest3DBuilder extends RequestBuilder<PaymentRequest3D> {
     private final PaymentData paymentData;
     private final UserData userData;
     private final SplitSettlementData splitSettlementData;
+    private final Map<String, String> additionalData;
 
     public PaymentRequest3DBuilder(final String merchantAccount,
                                    final PaymentData paymentData,
                                    final UserData userData,
-                                   @Nullable final SplitSettlementData splitSettlementData) {
+                                   @Nullable final SplitSettlementData splitSettlementData,
+                                   @Nullable final Map<String, String> additionalData) {
         super(new PaymentRequest3D());
         final AnyType2AnyTypeMap map = new AnyType2AnyTypeMap();
         request.setAdditionalData(map);
@@ -56,6 +59,7 @@ public class PaymentRequest3DBuilder extends RequestBuilder<PaymentRequest3D> {
         this.paymentData = paymentData;
         this.userData = userData;
         this.splitSettlementData = splitSettlementData;
+        this.additionalData = additionalData;
     }
 
     @Override
@@ -68,6 +72,7 @@ public class PaymentRequest3DBuilder extends RequestBuilder<PaymentRequest3D> {
         setShopperData();
         set3DSecureFields();
         setSplitSettlementData();
+        addAdditionalData(request.getAdditionalData(), additionalData);
 
         return request;
     }

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/builder/PaymentRequestBuilder.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/builder/PaymentRequestBuilder.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014-2016 Groupon, Inc
- * Copyright 2014-2016 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -19,6 +19,7 @@ package org.killbill.billing.plugin.adyen.client.payment.builder;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 
 import javax.annotation.Nullable;
 import javax.xml.datatype.DatatypeConfigurationException;
@@ -47,17 +48,20 @@ public class PaymentRequestBuilder extends RequestBuilder<PaymentRequest> {
     private final PaymentData paymentData;
     private final UserData userData;
     private final SplitSettlementData splitSettlementData;
+    private final Map<String, String> additionalData;
 
     public PaymentRequestBuilder(final String merchantAccount,
                                  final PaymentData paymentData,
                                  final UserData userData,
                                  @Nullable final SplitSettlementData splitSettlementData,
+                                 @Nullable final Map<String, String> additionalData,
                                  final PaymentInfoConverterManagement paymentInfoConverterManagement) {
         super(paymentInfoConverterManagement.convertPaymentInfoToPaymentRequest(paymentData.getPaymentInfo()));
         this.merchantAccount = merchantAccount;
         this.paymentData = paymentData;
         this.userData = userData;
         this.splitSettlementData = splitSettlementData;
+        this.additionalData = additionalData;
     }
 
     @Override
@@ -70,6 +74,7 @@ public class PaymentRequestBuilder extends RequestBuilder<PaymentRequest> {
         setShopperData();
         set3DSecureFields();
         setSplitSettlementData();
+        addAdditionalData(request.getAdditionalData(), additionalData);
 
         return request;
     }

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/builder/RequestBuilder.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/builder/RequestBuilder.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2014 Groupon, Inc
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
- * Groupon licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *
@@ -18,6 +19,7 @@ package org.killbill.billing.plugin.adyen.client.payment.builder;
 
 import java.math.BigDecimal;
 import java.util.Collection;
+import java.util.Map;
 
 import javax.annotation.Nullable;
 
@@ -49,5 +51,13 @@ public abstract class RequestBuilder<R> {
             return null;
         }
         return KillBillMoney.toMinorUnits(currencyIsoCode, amountBD);
+    }
+
+    protected void addAdditionalData(final AnyType2AnyTypeMap additionalDataEntries, @Nullable final Map<String, String> additionalData) {
+        if (additionalData != null) {
+            for (final String key : additionalData.keySet()) {
+                addAdditionalDataEntry(additionalDataEntries.getEntry(), key, additionalData.get(key));
+            }
+        }
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/AdyenPaymentServiceProviderPort.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/payment/service/AdyenPaymentServiceProviderPort.java
@@ -70,24 +70,27 @@ public class AdyenPaymentServiceProviderPort extends BaseAdyenPaymentServiceProv
     public PurchaseResult authorise(final String merchantAccount,
                                     final PaymentData paymentData,
                                     final UserData userData,
-                                    final SplitSettlementData splitSettlementData) {
-        return authoriseOrCredit(true, merchantAccount, paymentData, userData, splitSettlementData);
+                                    final SplitSettlementData splitSettlementData,
+                                    final Map<String, String> additionalData) {
+        return authoriseOrCredit(true, merchantAccount, paymentData, userData, splitSettlementData, additionalData);
     }
 
     public PurchaseResult credit(final String merchantAccount,
                                  final PaymentData paymentData,
                                  final UserData userData,
-                                 final SplitSettlementData splitSettlementData) {
-        return authoriseOrCredit(false, merchantAccount, paymentData, userData, splitSettlementData);
+                                 final SplitSettlementData splitSettlementData,
+                                 final Map<String, String> additionalData) {
+        return authoriseOrCredit(false, merchantAccount, paymentData, userData, splitSettlementData, additionalData);
     }
 
     private PurchaseResult authoriseOrCredit(final boolean authorize,
                                              final String merchantAccount,
                                              final PaymentData paymentData,
                                              final UserData userData,
-                                             final SplitSettlementData splitSettlementData) {
+                                             final SplitSettlementData splitSettlementData,
+                                             final Map<String, String> additionalData) {
         final String operation = authorize ? "authorize" : "credit";
-        final PaymentRequest request = adyenRequestFactory.createPaymentRequest(merchantAccount, paymentData, userData, splitSettlementData);
+        final PaymentRequest request = adyenRequestFactory.createPaymentRequest(merchantAccount, paymentData, userData, splitSettlementData, additionalData);
 
         final AdyenCallResult<PaymentResult> adyenCallResult;
         if (authorize) {
@@ -170,12 +173,14 @@ public class AdyenPaymentServiceProviderPort extends BaseAdyenPaymentServiceProv
     public PurchaseResult authorize3DSecure(final String merchantAccount,
                                             final PaymentData paymentData,
                                             final UserData userData,
-                                            final SplitSettlementData splitSettlementData) {
+                                            final SplitSettlementData splitSettlementData,
+                                            final Map<String, String> additionalData) {
         final String operation = "authorize3DSecure";
         final PaymentRequest3D request = adyenRequestFactory.paymentRequest3d(merchantAccount,
                                                                               paymentData,
                                                                               userData,
-                                                                              splitSettlementData);
+                                                                              splitSettlementData,
+                                                                              additionalData);
         final AdyenCallResult<PaymentResult> adyenCallResult = adyenPaymentRequestSender.authorise3D(merchantAccount, request);
 
         if (!adyenCallResult.receivedWellFormedResponse()) {
@@ -216,7 +221,8 @@ public class AdyenPaymentServiceProviderPort extends BaseAdyenPaymentServiceProv
     public PaymentModificationResponse refund(final String merchantAccount,
                                               final PaymentData paymentData,
                                               final String pspReference,
-                                              final SplitSettlementData splitSettlementData) {
+                                              final SplitSettlementData splitSettlementData,
+                                              final Map<String, String> additionalData) {
         return modify("refund",
                       new ModificationExecutor() {
                           @Override
@@ -227,13 +233,15 @@ public class AdyenPaymentServiceProviderPort extends BaseAdyenPaymentServiceProv
                       merchantAccount,
                       paymentData,
                       pspReference,
-                      splitSettlementData);
+                      splitSettlementData,
+                      additionalData);
     }
 
     public PaymentModificationResponse cancel(final String merchantAccount,
                                               final PaymentData paymentData,
                                               final String pspReference,
-                                              final SplitSettlementData splitSettlementData) {
+                                              final SplitSettlementData splitSettlementData,
+                                              final Map<String, String> additionalData) {
         return modify("cancel",
                       new ModificationExecutor() {
                           @Override
@@ -244,13 +252,15 @@ public class AdyenPaymentServiceProviderPort extends BaseAdyenPaymentServiceProv
                       merchantAccount,
                       paymentData,
                       pspReference,
-                      splitSettlementData);
+                      splitSettlementData,
+                      additionalData);
     }
 
     public PaymentModificationResponse capture(final String merchantAccount,
                                                final PaymentData paymentData,
                                                final String pspReference,
-                                               final SplitSettlementData splitSettlementData) {
+                                               final SplitSettlementData splitSettlementData,
+                                               final Map<String, String> additionalData) {
         return modify("capture",
                       new ModificationExecutor() {
                           @Override
@@ -261,7 +271,8 @@ public class AdyenPaymentServiceProviderPort extends BaseAdyenPaymentServiceProv
                       merchantAccount,
                       paymentData,
                       pspReference,
-                      splitSettlementData);
+                      splitSettlementData,
+                      additionalData);
     }
 
     private PaymentModificationResponse modify(final String operation,
@@ -269,8 +280,9 @@ public class AdyenPaymentServiceProviderPort extends BaseAdyenPaymentServiceProv
                                                final String merchantAccount,
                                                final PaymentData paymentData,
                                                final String pspReference,
-                                               final SplitSettlementData splitSettlementData) {
-        final ModificationRequest modificationRequest = adyenRequestFactory.createModificationRequest(merchantAccount, paymentData, pspReference, splitSettlementData);
+                                               final SplitSettlementData splitSettlementData,
+                                               final Map<String, String> additionalData) {
+        final ModificationRequest modificationRequest = adyenRequestFactory.createModificationRequest(merchantAccount, paymentData, pspReference, splitSettlementData, additionalData);
         final AdyenCallResult<ModificationResult> adyenCall = modificationExecutor.execute(modificationRequest);
 
         final PaymentModificationResponse response;
@@ -345,17 +357,6 @@ public class AdyenPaymentServiceProviderPort extends BaseAdyenPaymentServiceProv
             }
         }
         return additionalDataMap;
-    }
-
-    private Map<Object, Object> entriesToMap(final AnyType2AnyTypeMap dataMap) {
-        final Map<Object, Object> map = new HashMap<Object, Object>();
-        if (dataMap != null) {
-            final List<AnyType2AnyTypeMap.Entry> result = dataMap.getEntry();
-            for (final AnyType2AnyTypeMap.Entry entry : result) {
-                map.put(entry.getKey(), entry.getValue());
-            }
-        }
-        return map;
     }
 
     private abstract static class ModificationExecutor {

--- a/src/test/java/org/killbill/billing/plugin/adyen/TestRemoteBase.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/TestRemoteBase.java
@@ -89,13 +89,15 @@ public abstract class TestRemoteBase {
     protected Properties properties;
     protected String merchantAccount;
 
-    @BeforeClass(groups = {"slow", "integration"})
+    @BeforeClass(groups = "slow")
     public void setUpBeforeClassCommon() throws Exception {
         logService = TestUtils.buildLogService();
     }
 
     @BeforeClass(groups = "integration")
     public void setUpBeforeClass() throws Exception {
+        setUpBeforeClassCommon();
+
         properties = TestUtils.loadProperties(PROPERTIES_FILE_NAME);
         adyenConfigProperties = getAdyenConfigProperties();
 

--- a/src/test/java/org/killbill/billing/plugin/adyen/client/payment/builder/TestModificationRequestBuilder.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/client/payment/builder/TestModificationRequestBuilder.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014-2016 Groupon, Inc
- * Copyright 2014-2016 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -19,6 +19,7 @@ package org.killbill.billing.plugin.adyen.client.payment.builder;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import org.killbill.adyen.payment.AnyType2AnyTypeMap.Entry;
@@ -78,8 +79,9 @@ public class TestModificationRequestBuilder extends BaseTestPaymentRequestBuilde
         final String paymentTransactionExternalKey = UUID.randomUUID().toString();
         final PaymentData paymentData = new PaymentData<Card>(new BigDecimal("20"), Currency.EUR, paymentTransactionExternalKey, new Card());
         final String originalReference = UUID.randomUUID().toString();
+        final Map<String, String> additionalData = null;
 
-        final ModificationRequestBuilder builder = new ModificationRequestBuilder(merchantAccount, paymentData, originalReference, splitSettlementData);
+        final ModificationRequestBuilder builder = new ModificationRequestBuilder(merchantAccount, paymentData, originalReference, splitSettlementData, additionalData);
         final ModificationRequest modificationRequest = builder.build();
 
         Assert.assertEquals(modificationRequest.getMerchantAccount(), merchantAccount);

--- a/src/test/java/org/killbill/billing/plugin/adyen/client/payment/builder/TestPaymentRequest3DBuilder.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/client/payment/builder/TestPaymentRequest3DBuilder.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014-2016 Groupon, Inc
- * Copyright 2014-2016 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -19,6 +19,7 @@ package org.killbill.billing.plugin.adyen.client.payment.builder;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import org.killbill.adyen.payment.AnyType2AnyTypeMap.Entry;
@@ -45,8 +46,9 @@ public class TestPaymentRequest3DBuilder extends BaseTestPaymentRequestBuilder {
         final PaymentData paymentData = new PaymentData<Card>(new BigDecimal("20"), Currency.EUR, paymentTransactionExternalKey, new Card());
         final UserData userData = new UserData();
         final SplitSettlementData splitSettlementData = null;
+        final Map<String, String> additionalData = null;
 
-        final PaymentRequest3DBuilder builder = new PaymentRequest3DBuilder(merchantAccount, paymentData, userData, splitSettlementData);
+        final PaymentRequest3DBuilder builder = new PaymentRequest3DBuilder(merchantAccount, paymentData, userData, splitSettlementData, additionalData);
         final PaymentRequest3D paymentRequest = builder.build();
 
         Assert.assertEquals(paymentRequest.getMerchantAccount(), merchantAccount);
@@ -98,8 +100,9 @@ public class TestPaymentRequest3DBuilder extends BaseTestPaymentRequestBuilder {
                                                                                 ImmutableList.<SplitSettlementData.Item>of(new SplitSettlementData.Item(500, "deal1", "voucherId", "voucher"),
                                                                                                                            new SplitSettlementData.Item(750, "deal1", "voucherId2", "voucher"),
                                                                                                                            new SplitSettlementData.Item(750, "deal2", "travelId", "travel")));
+        final Map<String, String> additionalData = null;
 
-        final PaymentRequest3DBuilder builder = new PaymentRequest3DBuilder(merchantAccount, paymentData, userData, splitSettlementData);
+        final PaymentRequest3DBuilder builder = new PaymentRequest3DBuilder(merchantAccount, paymentData, userData, splitSettlementData, additionalData);
         final PaymentRequest3D paymentRequest = builder.build();
 
         Assert.assertEquals(paymentRequest.getMerchantAccount(), merchantAccount);

--- a/src/test/java/org/killbill/billing/plugin/adyen/client/payment/builder/TestPaymentRequestBuilder.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/client/payment/builder/TestPaymentRequestBuilder.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014-2016 Groupon, Inc
- * Copyright 2014-2016 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -19,6 +19,7 @@ package org.killbill.billing.plugin.adyen.client.payment.builder;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import org.killbill.adyen.payment.AnyType2AnyTypeMap;
@@ -46,9 +47,10 @@ public class TestPaymentRequestBuilder extends BaseTestPaymentRequestBuilder {
         final PaymentData paymentData = new PaymentData<Card>(new BigDecimal("20"), Currency.EUR, paymentTransactionExternalKey, new Card());
         final UserData userData = new UserData();
         final SplitSettlementData splitSettlementData = null;
+        final Map<String, String> additionalData = null;
         final PaymentInfoConverterService paymentInfoConverterManagement = new PaymentInfoConverterService();
 
-        final PaymentRequestBuilder builder = new PaymentRequestBuilder(merchantAccount, paymentData, userData, splitSettlementData, paymentInfoConverterManagement);
+        final PaymentRequestBuilder builder = new PaymentRequestBuilder(merchantAccount, paymentData, userData, splitSettlementData, additionalData, paymentInfoConverterManagement);
         final PaymentRequest paymentRequest = builder.build();
 
         Assert.assertEquals(paymentRequest.getMerchantAccount(), merchantAccount);
@@ -125,9 +127,11 @@ public class TestPaymentRequestBuilder extends BaseTestPaymentRequestBuilder {
                                                                                                                            new SplitSettlementData.Item(750, "deal1", "voucherId2", "voucher"),
                                                                                                                            new SplitSettlementData.Item(750, "deal2", "travelId", "travel")));
 
+        final Map<String, String> additionalData = null;
+
         final PaymentInfoConverterService paymentInfoConverterManagement = new PaymentInfoConverterService();
 
-        final PaymentRequestBuilder builder = new PaymentRequestBuilder(merchantAccount, paymentData, userData, splitSettlementData, paymentInfoConverterManagement);
+        final PaymentRequestBuilder builder = new PaymentRequestBuilder(merchantAccount, paymentData, userData, splitSettlementData, additionalData, paymentInfoConverterManagement);
         final PaymentRequest paymentRequest = builder.build();
 
         Assert.assertEquals(paymentRequest.getMerchantAccount(), merchantAccount);

--- a/src/test/java/org/killbill/billing/plugin/adyen/client/payment/service/TestRemoteAdyenPaymentServiceProviderPort.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/client/payment/service/TestRemoteAdyenPaymentServiceProviderPort.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014-2016 Groupon, Inc
- * Copyright 2014-2016 The Billing Project, LLC
+ * Copyright 2014-2018 Groupon, Inc
+ * Copyright 2014-2018 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -18,6 +18,7 @@
 package org.killbill.billing.plugin.adyen.client.payment.service;
 
 import java.math.BigDecimal;
+import java.util.Map;
 import java.util.UUID;
 
 import org.killbill.billing.catalog.api.Currency;
@@ -44,8 +45,9 @@ public class TestRemoteAdyenPaymentServiceProviderPort extends TestRemoteBase {
         final PaymentData<Card> paymentData = new PaymentData<Card>(BigDecimal.TEN, DEFAULT_CURRENCY, UUID.randomUUID().toString(), getCreditCard());
         final UserData userData = new UserData();
         final SplitSettlementData splitSettlementData = null;
+        final Map<String, String> additionalData = null;
 
-        final PurchaseResult authorizeResult = adyenPaymentServiceProviderPort.authorise(merchantAccount, paymentData, userData, splitSettlementData);
+        final PurchaseResult authorizeResult = adyenPaymentServiceProviderPort.authorise(merchantAccount, paymentData, userData, splitSettlementData, additionalData);
         // Adyen's unique reference that is associated with the payment
         Assert.assertNotNull(authorizeResult.getPspReference());
         // Result of the payment. The possible values are Authorised, Refused, Error or Received (as with a Dutch Direct Debit)
@@ -60,13 +62,13 @@ public class TestRemoteAdyenPaymentServiceProviderPort extends TestRemoteBase {
 
         // First capture
         final PaymentData paymentData1 = new PaymentData<Card>(captureAmount, DEFAULT_CURRENCY, UUID.randomUUID().toString(), getCreditCard());
-        final PaymentModificationResponse capture1Result = adyenPaymentServiceProviderPort.capture(merchantAccount, paymentData1, pspReference, splitSettlementData);
+        final PaymentModificationResponse capture1Result = adyenPaymentServiceProviderPort.capture(merchantAccount, paymentData1, pspReference, splitSettlementData, additionalData);
         Assert.assertNotNull(capture1Result.getPspReference());
         Assert.assertEquals(capture1Result.getResponse(), "[capture-received]");
 
         // Second capture
         final PaymentData paymentData2 = new PaymentData<Card>(captureAmount, DEFAULT_CURRENCY, UUID.randomUUID().toString(), getCreditCard());
-        final PaymentModificationResponse capture2Result = adyenPaymentServiceProviderPort.capture(merchantAccount, paymentData2, pspReference, splitSettlementData);
+        final PaymentModificationResponse capture2Result = adyenPaymentServiceProviderPort.capture(merchantAccount, paymentData2, pspReference, splitSettlementData, additionalData);
         Assert.assertNotNull(capture2Result.getPspReference());
         Assert.assertEquals(capture2Result.getResponse(), "[capture-received]");
     }
@@ -76,8 +78,9 @@ public class TestRemoteAdyenPaymentServiceProviderPort extends TestRemoteBase {
         final PaymentData<Card> paymentData = new PaymentData<Card>(BigDecimal.TEN, DEFAULT_CURRENCY, UUID.randomUUID().toString(), getCreditCard());
         final UserData userData = new UserData();
         final SplitSettlementData splitSettlementData = null;
+        final Map<String, String> additionalData = null;
 
-        final PurchaseResult authorizeResult = adyenPaymentServiceProviderPort.authorise(merchantAccount, paymentData, userData, splitSettlementData);
+        final PurchaseResult authorizeResult = adyenPaymentServiceProviderPort.authorise(merchantAccount, paymentData, userData, splitSettlementData, additionalData);
         Assert.assertNotNull(authorizeResult.getPspReference());
         Assert.assertEquals(authorizeResult.getResultCode(), "Authorised");
         Assert.assertNotNull(authorizeResult.getAuthCode());
@@ -86,7 +89,7 @@ public class TestRemoteAdyenPaymentServiceProviderPort extends TestRemoteBase {
         final String pspReference = authorizeResult.getPspReference();
 
         final PaymentData paymentData1 = new PaymentData<Card>(null, null, UUID.randomUUID().toString(), getCreditCard());
-        final PaymentModificationResponse voidResult = adyenPaymentServiceProviderPort.cancel(merchantAccount, paymentData1, pspReference, splitSettlementData);
+        final PaymentModificationResponse voidResult = adyenPaymentServiceProviderPort.cancel(merchantAccount, paymentData1, pspReference, splitSettlementData, additionalData);
         Assert.assertNotNull(voidResult.getPspReference());
         Assert.assertEquals(voidResult.getResponse(), "[cancel-received]");
     }
@@ -96,8 +99,9 @@ public class TestRemoteAdyenPaymentServiceProviderPort extends TestRemoteBase {
         final PaymentData<Card> paymentData = new PaymentData<Card>(BigDecimal.TEN, DEFAULT_CURRENCY, UUID.randomUUID().toString(), getCreditCard());
         final UserData userData = new UserData();
         final SplitSettlementData splitSettlementData = null;
+        final Map<String, String> additionalData = null;
 
-        final PurchaseResult authorizeResult = adyenPaymentServiceProviderPort.authorise(merchantAccount, paymentData, userData, splitSettlementData);
+        final PurchaseResult authorizeResult = adyenPaymentServiceProviderPort.authorise(merchantAccount, paymentData, userData, splitSettlementData, additionalData);
         Assert.assertNotNull(authorizeResult.getPspReference());
         Assert.assertEquals(authorizeResult.getResultCode(), "Authorised");
         Assert.assertNotNull(authorizeResult.getAuthCode());
@@ -108,7 +112,7 @@ public class TestRemoteAdyenPaymentServiceProviderPort extends TestRemoteBase {
         final String capturePspReference = authorizeResult.getPspReference();
 
         final PaymentData paymentData1 = new PaymentData<Card>(captureAmount, DEFAULT_CURRENCY, UUID.randomUUID().toString(), getCreditCard());
-        final PaymentModificationResponse captureResult = adyenPaymentServiceProviderPort.capture(merchantAccount, paymentData1, capturePspReference, splitSettlementData);
+        final PaymentModificationResponse captureResult = adyenPaymentServiceProviderPort.capture(merchantAccount, paymentData1, capturePspReference, splitSettlementData, additionalData);
         Assert.assertNotNull(captureResult.getPspReference());
         Assert.assertEquals(captureResult.getResponse(), "[capture-received]");
 
@@ -117,7 +121,7 @@ public class TestRemoteAdyenPaymentServiceProviderPort extends TestRemoteBase {
         final String refundPspReference = captureResult.getPspReference();
 
         final PaymentData paymentData2 = new PaymentData<Card>(refundAmount, DEFAULT_CURRENCY, UUID.randomUUID().toString(), getCreditCard());
-        final PaymentModificationResponse refundResult = adyenPaymentServiceProviderPort.refund(merchantAccount, paymentData2, refundPspReference, splitSettlementData);
+        final PaymentModificationResponse refundResult = adyenPaymentServiceProviderPort.refund(merchantAccount, paymentData2, refundPspReference, splitSettlementData, additionalData);
         Assert.assertNotNull(refundResult.getPspReference());
         Assert.assertEquals(refundResult.getResponse(), "[refund-received]");
     }
@@ -127,8 +131,9 @@ public class TestRemoteAdyenPaymentServiceProviderPort extends TestRemoteBase {
         final PaymentData<Card> paymentData = new PaymentData<Card>(BigDecimal.TEN, DEFAULT_CURRENCY, UUID.randomUUID().toString(), getCreditCard());
         final UserData userData = new UserData();
         final SplitSettlementData splitSettlementData = null;
+        final Map<String, String> additionalData = null;
 
-        final PurchaseResult authorizeResult = adyenPaymentServiceProviderPort.authorise(merchantAccount, paymentData, userData, splitSettlementData);
+        final PurchaseResult authorizeResult = adyenPaymentServiceProviderPort.authorise(merchantAccount, paymentData, userData, splitSettlementData, additionalData);
         Assert.assertNotNull(authorizeResult.getPspReference());
         Assert.assertEquals(authorizeResult.getResultCode(), "Authorised");
         Assert.assertNotNull(authorizeResult.getAuthCode());
@@ -137,7 +142,7 @@ public class TestRemoteAdyenPaymentServiceProviderPort extends TestRemoteBase {
         final String pspReference = UUID.randomUUID().toString();
 
         final PaymentData paymentData1 = new PaymentData<Card>(null, null, UUID.randomUUID().toString(), getCreditCard());
-        final PaymentModificationResponse voidResult = adyenPaymentServiceProviderPort.cancel(merchantAccount, paymentData1, pspReference, splitSettlementData);
+        final PaymentModificationResponse voidResult = adyenPaymentServiceProviderPort.cancel(merchantAccount, paymentData1, pspReference, splitSettlementData, additionalData);
         assertFalse(voidResult.isTechnicallySuccessful());
     }
 
@@ -154,8 +159,9 @@ public class TestRemoteAdyenPaymentServiceProviderPort extends TestRemoteBase {
         final PaymentData<Card> paymentData = new PaymentData<Card>(new BigDecimal("1"), DEFAULT_CURRENCY, UUID.randomUUID().toString(), creditCard);
         final UserData userData = new UserData();
         final SplitSettlementData splitSettlementData = null;
+        final Map<String, String> additionalData = null;
 
-        final PurchaseResult authorizeResult = adyenPaymentServiceProviderPort.authorise(merchantAccount, paymentData, userData, splitSettlementData);
+        final PurchaseResult authorizeResult = adyenPaymentServiceProviderPort.authorise(merchantAccount, paymentData, userData, splitSettlementData, additionalData);
         Assert.assertNotNull(authorizeResult.getPspReference());
         Assert.assertEquals(authorizeResult.getResultCode(), "Authorised");
         Assert.assertNotNull(authorizeResult.getAuthCode());
@@ -174,8 +180,9 @@ public class TestRemoteAdyenPaymentServiceProviderPort extends TestRemoteBase {
         userData.setFirstName("José");
         userData.setLastName("Silva");
         final SplitSettlementData splitSettlementData = null;
+        final Map<String, String> additionalData = null;
 
-        final PurchaseResult authorizeResult = adyenPaymentServiceProviderPort.authorise(merchantAccount, paymentData, userData, splitSettlementData);
+        final PurchaseResult authorizeResult = adyenPaymentServiceProviderPort.authorise(merchantAccount, paymentData, userData, splitSettlementData, additionalData);
         Assert.assertNotNull(authorizeResult.getPspReference());
         Assert.assertEquals(authorizeResult.getResultCode(), "Received");
         Assert.assertNull(authorizeResult.getAuthCode());


### PR DESCRIPTION
Arbitrary additionalData parameters can now be sent to Adyen.

The format is similar to the one used for split settlements. For instance,
to send RequestedTestAcquirerResponseCode=6, specify the following two
plugin properties:

```
additionalDataItem.1.key=RequestedTestAcquirerResponseCode
additionalDataItem.1.value=6
```

This fixes https://github.com/killbill/killbill-adyen-plugin/issues/83.

/cc @breynolds-squaretrade