### PR TITLE
Expand expiry policy for HPP payment without completion action

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentPluginApi.java
@@ -781,8 +781,8 @@ public class AdyenPaymentPluginApi extends PluginPaymentPluginApi<AdyenResponses
 
     private AdyenResponsesRecord fetchResponseIfExist(final UUID kbPaymentId, final UUID tenantId) throws PaymentPluginApiException {
         try {
-            return dao.getResponses(kbPaymentId, tenantId).stream().findFirst().orElse(null);
-        } catch (SQLException e) {
+            return dao.getSuccessfulAuthorizationResponse(kbPaymentId, tenantId);
+        } catch (final SQLException e) {
             throw new PaymentPluginApiException("SQL exception when fetching response", e);
         }
     }

--- a/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentPluginApi.java
@@ -194,6 +194,7 @@ public class AdyenPaymentPluginApi extends PluginPaymentPluginApi<AdyenResponses
     public static final String PROPERTY_REASON = "reason";
     public static final String PROPERTY_SUCCESS = "success";
     public static final String PROPERTY_FROM_HPP = "fromHPP";
+    public static final String PROPERTY_HPP_COMPLETION = "fromHPPCompletion";
     public static final String PROPERTY_FROM_HPP_TRANSACTION_STATUS = "fromHPPTransactionStatus";
     public static final String PROPERTY_PA_REQ = "PaReq";
     public static final String PROPERTY_DCC_AMOUNT_VALUE = "dccAmount";
@@ -419,20 +420,16 @@ public class AdyenPaymentPluginApi extends PluginPaymentPluginApi<AdyenResponses
 
     @Override
     public PaymentTransactionInfoPlugin authorizePayment(final UUID kbAccountId, final UUID kbPaymentId, final UUID kbTransactionId, final UUID kbPaymentMethodId, final BigDecimal amount, final Currency currency, final Iterable<PluginProperty> properties, final CallContext context) throws PaymentPluginApiException {
-        final AdyenResponsesRecord adyenResponsesRecord;
-        try {
-            adyenResponsesRecord = dao.updateResponse(kbTransactionId, properties, context.getTenantId());
-        } catch (final SQLException e) {
-            throw new PaymentPluginApiException("HPP notification came through, but we encountered a database error", e);
-        }
-
+        final AdyenResponsesRecord adyenResponsesRecord = fetchResponseIfExist(kbPaymentId, context.getTenantId());
         final boolean isHPPCompletion = adyenResponsesRecord != null && Boolean.valueOf(MoreObjects.firstNonNull(AdyenDao.fromAdditionalData(adyenResponsesRecord.getAdditionalData()).get(PROPERTY_FROM_HPP), false).toString());
         if (!isHPPCompletion) {
+            updateResponseWithAdditionalProperties(kbTransactionId, properties, context.getTenantId());
             // We don't have any record for that payment: we want to trigger an actual authorization call (or complete a 3D-S authorization)
             return executeInitialTransaction(TransactionType.AUTHORIZE, kbAccountId, kbPaymentId, kbTransactionId, kbPaymentMethodId, amount, currency, properties, context);
         } else {
             // We already have a record for that payment transaction and we just updated the response row with additional properties
             // (the API can be called for instance after the user is redirected back from the HPP to store the PSP reference)
+            updateResponseWithAdditionalProperties(kbTransactionId, PluginProperties.merge(ImmutableMap.of(PROPERTY_HPP_COMPLETION, true), properties), context.getTenantId());
         }
 
         return buildPaymentTransactionInfoPlugin(adyenResponsesRecord);
@@ -771,6 +768,22 @@ public class AdyenPaymentPluginApi extends PluginPaymentPluginApi<AdyenResponses
             return new AdyenPaymentTransactionInfoPlugin(kbPaymentId, kbTransactionId, transactionType, amount, currency, paymentServiceProviderResult, utcNow, response);
         } catch (final SQLException e) {
             throw new PaymentPluginApiException("Payment went through, but we encountered a database error. Payment details: " + (response.toString()), e);
+        }
+    }
+
+    private void updateResponseWithAdditionalProperties(final UUID kbTransactionId, final Iterable<PluginProperty> properties, final UUID tenantId) throws PaymentPluginApiException {
+        try {
+            dao.updateResponse(kbTransactionId, properties, tenantId);
+        } catch (final SQLException e) {
+            throw new PaymentPluginApiException("SQL exception when updating response", e);
+        }
+    }
+
+    private AdyenResponsesRecord fetchResponseIfExist(final UUID kbPaymentId, final UUID tenantId) throws PaymentPluginApiException {
+        try {
+            return dao.getResponses(kbPaymentId, tenantId).stream().findFirst().orElse(null);
+        } catch (SQLException e) {
+            throw new PaymentPluginApiException("SQL exception when fetching response", e);
         }
     }
 

--- a/src/main/java/org/killbill/billing/plugin/adyen/api/ExpiredPaymentPolicy.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/api/ExpiredPaymentPolicy.java
@@ -83,7 +83,7 @@ public class ExpiredPaymentPolicy {
         if (is3ds(transaction)) {
             return transaction.getCreatedDate().plus(adyenProperties.getPending3DsPaymentExpirationPeriod());
         } else if(isHppBuildFormTransaction(transaction)) {
-            return transaction.getCreatedDate().plus(adyenProperties.getPendingHppPaymentWithouCompletionExpirationPeriod());
+            return transaction.getCreatedDate().plus(adyenProperties.getPendingHppPaymentWithoutCompletionExpirationPeriod());
         }
 
         final String paymentMethod = getPaymentMethod(transaction);

--- a/src/main/java/org/killbill/billing/plugin/adyen/api/ExpiredPaymentPolicy.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/api/ExpiredPaymentPolicy.java
@@ -25,11 +25,16 @@ import org.killbill.billing.payment.plugin.api.PaymentPluginStatus;
 import org.killbill.billing.payment.plugin.api.PaymentTransactionInfoPlugin;
 import org.killbill.billing.plugin.adyen.client.AdyenConfigProperties;
 import org.killbill.billing.plugin.adyen.client.model.PaymentServiceProviderResult;
+import org.killbill.billing.plugin.adyen.dao.AdyenDao;
 import org.killbill.billing.plugin.adyen.dao.gen.tables.records.AdyenResponsesRecord;
 import org.killbill.billing.plugin.api.PluginProperties;
 import org.killbill.clock.Clock;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.Iterables;
+
+import static org.killbill.billing.plugin.adyen.api.AdyenPaymentPluginApi.PROPERTY_FROM_HPP;
+import static org.killbill.billing.plugin.adyen.api.AdyenPaymentPluginApi.PROPERTY_HPP_COMPLETION;
 
 public class ExpiredPaymentPolicy {
 
@@ -53,7 +58,7 @@ public class ExpiredPaymentPolicy {
         }
 
         if (transaction.getStatus() == PaymentPluginStatus.PENDING) {
-            final DateTime expirationDate = expirationDate(transaction);
+            final DateTime expirationDate = expirationDateForInitialTransactionType(transaction);
             return clock.getNow(expirationDate.getZone()).isAfter(expirationDate);
         }
 
@@ -74,13 +79,24 @@ public class ExpiredPaymentPolicy {
         return true;
     }
 
-    private DateTime expirationDate(final AdyenPaymentTransactionInfoPlugin transaction) {
+    private DateTime expirationDateForInitialTransactionType(final AdyenPaymentTransactionInfoPlugin transaction) {
         if (is3ds(transaction)) {
             return transaction.getCreatedDate().plus(adyenProperties.getPending3DsPaymentExpirationPeriod());
+        } else if(isHppBuildFormTransaction(transaction)) {
+            return transaction.getCreatedDate().plus(adyenProperties.getPendingHppPaymentWithouCompletionExpirationPeriod());
         }
 
         final String paymentMethod = getPaymentMethod(transaction);
         return transaction.getCreatedDate().plus(adyenProperties.getPendingPaymentExpirationPeriod(paymentMethod));
+    }
+
+    private boolean isHppBuildFormTransaction(final AdyenPaymentTransactionInfoPlugin transaction) {
+        if (!transaction.getAdyenResponseRecord().isPresent()) {
+            return false;
+        }
+
+        final AdyenResponsesRecord adyenResponsesRecord = transaction.getAdyenResponseRecord().get();
+        return isHppPayment(adyenResponsesRecord) && !isHppCompletionTransaction(adyenResponsesRecord);
     }
 
     private boolean is3ds(final AdyenPaymentTransactionInfoPlugin transaction) {
@@ -89,7 +105,17 @@ public class ExpiredPaymentPolicy {
         }
 
         final AdyenResponsesRecord adyenResponsesRecord = transaction.getAdyenResponseRecord().get();
-        return PaymentServiceProviderResult.REDIRECT_SHOPPER.toString().equals(adyenResponsesRecord.getResultCode());
+        //Redirect shopper response can exist for both 3-DS or HPP pending payment.
+        return PaymentServiceProviderResult.REDIRECT_SHOPPER.toString().equals(adyenResponsesRecord.getResultCode())
+               && !isHppPayment(adyenResponsesRecord);
+    }
+
+    private boolean isHppCompletionTransaction(final AdyenResponsesRecord adyenResponsesRecord) {
+        return Boolean.valueOf(MoreObjects.firstNonNull(AdyenDao.fromAdditionalData(adyenResponsesRecord.getAdditionalData()).get(PROPERTY_HPP_COMPLETION), false).toString());
+    }
+
+    private boolean isHppPayment(final AdyenResponsesRecord adyenResponsesRecord) {
+        return Boolean.valueOf(MoreObjects.firstNonNull(AdyenDao.fromAdditionalData(adyenResponsesRecord.getAdditionalData()).get(PROPERTY_FROM_HPP), false).toString());
     }
 
     // paymentMethod comes from the notification, brandCode from the HPP request

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/AdyenConfigProperties.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/AdyenConfigProperties.java
@@ -38,6 +38,7 @@ public class AdyenConfigProperties {
 
     public static final String DEFAULT_PENDING_PAYMENT_EXPIRATION_PERIOD = "P3d";
     public static final String DEFAULT_PENDING_3DS_PAYMENT_EXPIRATION_PERIOD = "PT3h";
+    public static final String DEFAULT_PENDING_HPP_PAYMENT_WITHOUT_COMPLETION_EXPIRATION_PERIOD = "PT3h";
     // Online (real-time) bank transfers offer merchants payment with immediate online authorisation via a customer’s bank, usually followed by next-day settlement.
     public static final List<String> DEFAULT_ONLINE_BANK_TRANSFER_PAYMENT_METHODS = ImmutableList.<String>of("giropay", "ideal", "paypal");
     // Period is a bit generous by default. Decision is synchronous with the redirect, but Adyen might have notification delays.
@@ -94,6 +95,8 @@ public class AdyenConfigProperties {
 
     private final Period pendingPaymentExpirationPeriod;
 
+    private final Period pendingHppPaymentWithouCompletionExpirationPeriod;
+
     private final Period pending3DsPaymentExpirationPeriod;
 
     private final String currentRegion;
@@ -136,6 +139,7 @@ public class AdyenConfigProperties {
 
         this.pendingPaymentExpirationPeriod = readPendingExpirationProperty(properties);
         this.pending3DsPaymentExpirationPeriod = read3DsPendingExpirationProperty(properties);
+        this.pendingHppPaymentWithouCompletionExpirationPeriod = readPendingHppPaymentWithouCompletionExpirationPeriod(properties);
 
         this.acquirersList = properties.getProperty(PROPERTY_PREFIX + "acquirersList");
 
@@ -198,6 +202,17 @@ public class AdyenConfigProperties {
             final String secretAlgorithm = countryOrSkinToSecretAlgorithmMap.get(countryOrSkin);
             skinToSecretAlgorithmMap.put(skin, secretAlgorithm);
         }
+    }
+
+    private Period readPendingHppPaymentWithouCompletionExpirationPeriod(final Properties properties) {
+        final String value = properties.getProperty(PROPERTY_PREFIX + "pendingHppPaymentWithoutCompletionExpirationPeriod");
+        if (value != null) {
+            try {
+                return Period.parse(value);
+            } catch (IllegalArgumentException e) { /* Ignore */ }
+        }
+
+        return Period.parse(DEFAULT_PENDING_HPP_PAYMENT_WITHOUT_COMPLETION_EXPIRATION_PERIOD);
     }
 
     private Period readPendingExpirationProperty(final Properties properties) {
@@ -424,5 +439,9 @@ public class AdyenConfigProperties {
                 }
             }
         }
+    }
+
+    public Period getPendingHppPaymentWithouCompletionExpirationPeriod() {
+        return pendingHppPaymentWithouCompletionExpirationPeriod;
     }
 }

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/AdyenConfigProperties.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/AdyenConfigProperties.java
@@ -95,7 +95,7 @@ public class AdyenConfigProperties {
 
     private final Period pendingPaymentExpirationPeriod;
 
-    private final Period pendingHppPaymentWithouCompletionExpirationPeriod;
+    private final Period pendingHppPaymentWithoutCompletionExpirationPeriod;
 
     private final Period pending3DsPaymentExpirationPeriod;
 
@@ -139,7 +139,7 @@ public class AdyenConfigProperties {
 
         this.pendingPaymentExpirationPeriod = readPendingExpirationProperty(properties);
         this.pending3DsPaymentExpirationPeriod = read3DsPendingExpirationProperty(properties);
-        this.pendingHppPaymentWithouCompletionExpirationPeriod = readPendingHppPaymentWithouCompletionExpirationPeriod(properties);
+        this.pendingHppPaymentWithoutCompletionExpirationPeriod = readPendingHppPaymentWithoutCompletionExpirationPeriod(properties);
 
         this.acquirersList = properties.getProperty(PROPERTY_PREFIX + "acquirersList");
 
@@ -204,12 +204,12 @@ public class AdyenConfigProperties {
         }
     }
 
-    private Period readPendingHppPaymentWithouCompletionExpirationPeriod(final Properties properties) {
+    private Period readPendingHppPaymentWithoutCompletionExpirationPeriod(final Properties properties) {
         final String value = properties.getProperty(PROPERTY_PREFIX + "pendingHppPaymentWithoutCompletionExpirationPeriod");
         if (value != null) {
             try {
                 return Period.parse(value);
-            } catch (IllegalArgumentException e) { /* Ignore */ }
+            } catch (final IllegalArgumentException e) { /* Ignore */ }
         }
 
         return Period.parse(DEFAULT_PENDING_HPP_PAYMENT_WITHOUT_COMPLETION_EXPIRATION_PERIOD);
@@ -441,7 +441,7 @@ public class AdyenConfigProperties {
         }
     }
 
-    public Period getPendingHppPaymentWithouCompletionExpirationPeriod() {
-        return pendingHppPaymentWithouCompletionExpirationPeriod;
+    public Period getPendingHppPaymentWithoutCompletionExpirationPeriod() {
+        return pendingHppPaymentWithoutCompletionExpirationPeriod;
     }
 }

--- a/src/test/java/org/killbill/billing/plugin/adyen/api/TestAdyenPaymentPluginApiHPP.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/api/TestAdyenPaymentPluginApiHPP.java
@@ -97,11 +97,11 @@ public class TestAdyenPaymentPluginApiHPP extends TestAdyenPaymentPluginApiBase 
     }
 
     @Test(groups = "integration")
-    public void testAuthorizeAndExpireHppWithoutCompletition() throws Exception {
+    public void testAuthorizeAndExpireHppWithoutCompletion() throws Exception {
         Payment payment = triggerBuildFormDescriptor(ImmutableMap.<String, String>of(AdyenPaymentPluginApi.PROPERTY_CREATE_PENDING_PAYMENT, "true",
                                                                    AdyenPaymentPluginApi.PROPERTY_AUTH_MODE, "true"),
                                    TransactionType.AUTHORIZE);
-        Period expirationPeriod = adyenConfigProperties.getPendingHppPaymentWithouCompletionExpirationPeriod().minusMinutes(1);
+        Period expirationPeriod = adyenConfigProperties.getPendingHppPaymentWithoutCompletionExpirationPeriod().minusMinutes(1);
         clock.setDeltaFromReality(expirationPeriod.toStandardDuration().getMillis());
 
         List<PaymentTransactionInfoPlugin> expiredPaymentTransactions = adyenPaymentPluginApi.getPaymentInfo(account.getId(),
@@ -113,7 +113,7 @@ public class TestAdyenPaymentPluginApiHPP extends TestAdyenPaymentPluginApiBase 
         assertEquals(pendingTrx.getTransactionType(), TransactionType.AUTHORIZE);
         assertEquals(pendingTrx.getStatus(), PaymentPluginStatus.PENDING);
 
-        expirationPeriod = adyenConfigProperties.getPendingHppPaymentWithouCompletionExpirationPeriod().plusMinutes(1);
+        expirationPeriod = adyenConfigProperties.getPendingHppPaymentWithoutCompletionExpirationPeriod().plusMinutes(1);
         clock.setDeltaFromReality(expirationPeriod.toStandardDuration().getMillis());
 
         expiredPaymentTransactions = adyenPaymentPluginApi.getPaymentInfo(account.getId(),
@@ -139,7 +139,7 @@ public class TestAdyenPaymentPluginApiHPP extends TestAdyenPaymentPluginApiBase 
                                                payment.getCurrency(),
                                                ImmutableList.of(),
                                                context);
-        Period expirationPeriod = adyenConfigProperties.getPendingHppPaymentWithouCompletionExpirationPeriod().plusMinutes(1);
+        Period expirationPeriod = adyenConfigProperties.getPendingHppPaymentWithoutCompletionExpirationPeriod().plusMinutes(1);
         clock.setDeltaFromReality(expirationPeriod.toStandardDuration().getMillis());
 
         List<PaymentTransactionInfoPlugin> paymentTransactions = adyenPaymentPluginApi.getPaymentInfo(account.getId(),

--- a/src/test/java/org/killbill/billing/plugin/adyen/client/TestAdyenConfigProperties.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/client/TestAdyenConfigProperties.java
@@ -53,7 +53,7 @@ public class TestAdyenConfigProperties {
         Assert.assertEquals(adyenConfigProperties.getHmacAlgorithm("DefaultSkin"), "HmacSHA256");
 
         Assert.assertEquals(adyenConfigProperties.getPending3DsPaymentExpirationPeriod().toString(), "PT3H");
-        Assert.assertEquals(adyenConfigProperties.getPendingHppPaymentWithouCompletionExpirationPeriod().toString(), "PT3H");
+        Assert.assertEquals(adyenConfigProperties.getPendingHppPaymentWithoutCompletionExpirationPeriod().toString(), "PT3H");
         Assert.assertEquals(adyenConfigProperties.getPendingPaymentExpirationPeriod(null).toString(), "P2D");
         // Don't use per-payment method default since user specified a global setting
         Assert.assertEquals(adyenConfigProperties.getPendingPaymentExpirationPeriod("paypal").toString(), "P2D");
@@ -101,7 +101,7 @@ public class TestAdyenConfigProperties {
         Assert.assertEquals(adyenConfigProperties.getHmacAlgorithm("DefaultSkinUS"), "DefaultAlgorithmUS");
 
         Assert.assertEquals(adyenConfigProperties.getPending3DsPaymentExpirationPeriod().toString(), "PT3H");
-        Assert.assertEquals(adyenConfigProperties.getPendingHppPaymentWithouCompletionExpirationPeriod().toString(), "PT3H");
+        Assert.assertEquals(adyenConfigProperties.getPendingHppPaymentWithoutCompletionExpirationPeriod().toString(), "PT3H");
         Assert.assertEquals(adyenConfigProperties.getPendingPaymentExpirationPeriod(null).toString(), "P3D");
         Assert.assertEquals(adyenConfigProperties.getPendingPaymentExpirationPeriod("paypal").toString(), "P4D");
         // Use per-payment method default since user did only override paypal
@@ -154,7 +154,7 @@ public class TestAdyenConfigProperties {
         Assert.assertEquals(adyenConfigProperties.getPendingPaymentExpirationPeriod(null).toString(), "P3D");
         Assert.assertEquals(adyenConfigProperties.getPendingPaymentExpirationPeriod("paypal").toString(), "P4D");
         Assert.assertEquals(adyenConfigProperties.getPendingPaymentExpirationPeriod("boletobancario_santander").toString(), "P12D");
-        Assert.assertEquals(adyenConfigProperties.getPendingHppPaymentWithouCompletionExpirationPeriod().toString(), "P12D");
+        Assert.assertEquals(adyenConfigProperties.getPendingHppPaymentWithoutCompletionExpirationPeriod().toString(), "P12D");
     }
 
     @Test(groups = "fast")

--- a/src/test/java/org/killbill/billing/plugin/adyen/client/TestAdyenConfigProperties.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/client/TestAdyenConfigProperties.java
@@ -53,6 +53,7 @@ public class TestAdyenConfigProperties {
         Assert.assertEquals(adyenConfigProperties.getHmacAlgorithm("DefaultSkin"), "HmacSHA256");
 
         Assert.assertEquals(adyenConfigProperties.getPending3DsPaymentExpirationPeriod().toString(), "PT3H");
+        Assert.assertEquals(adyenConfigProperties.getPendingHppPaymentWithouCompletionExpirationPeriod().toString(), "PT3H");
         Assert.assertEquals(adyenConfigProperties.getPendingPaymentExpirationPeriod(null).toString(), "P2D");
         // Don't use per-payment method default since user specified a global setting
         Assert.assertEquals(adyenConfigProperties.getPendingPaymentExpirationPeriod("paypal").toString(), "P2D");
@@ -100,6 +101,7 @@ public class TestAdyenConfigProperties {
         Assert.assertEquals(adyenConfigProperties.getHmacAlgorithm("DefaultSkinUS"), "DefaultAlgorithmUS");
 
         Assert.assertEquals(adyenConfigProperties.getPending3DsPaymentExpirationPeriod().toString(), "PT3H");
+        Assert.assertEquals(adyenConfigProperties.getPendingHppPaymentWithouCompletionExpirationPeriod().toString(), "PT3H");
         Assert.assertEquals(adyenConfigProperties.getPendingPaymentExpirationPeriod(null).toString(), "P3D");
         Assert.assertEquals(adyenConfigProperties.getPendingPaymentExpirationPeriod("paypal").toString(), "P4D");
         // Use per-payment method default since user did only override paypal
@@ -116,6 +118,7 @@ public class TestAdyenConfigProperties {
         properties.put("org.killbill.billing.plugin.adyen.hmac.secret", "UK#DefaultSecretUK|OverrideSkinUK#OverrideSecretUK|US#DefaultSecretUS|DE#DefaultSecretDE");
         properties.put("org.killbill.billing.plugin.adyen.hmac.algorithm", "UK#DefaultAlgorithmUK|OverrideSkinUK#OverrideAlgorithmUK|US#DefaultAlgorithmUS|DE#DefaultAlgorithmDE");
         properties.put("org.killbill.billing.plugin.adyen.pendingPaymentExpirationPeriod", "paypal#P4D|boletobancario_santander#P12D");
+        properties.put("org.killbill.billing.plugin.adyen.pendingHppPaymentWithoutCompletionExpirationPeriod", "P12D");
         final AdyenConfigProperties adyenConfigProperties = new AdyenConfigProperties(properties);
 
         Assert.assertEquals(adyenConfigProperties.getMerchantAccount("UK"), "DefaultAccountUK");
@@ -151,6 +154,7 @@ public class TestAdyenConfigProperties {
         Assert.assertEquals(adyenConfigProperties.getPendingPaymentExpirationPeriod(null).toString(), "P3D");
         Assert.assertEquals(adyenConfigProperties.getPendingPaymentExpirationPeriod("paypal").toString(), "P4D");
         Assert.assertEquals(adyenConfigProperties.getPendingPaymentExpirationPeriod("boletobancario_santander").toString(), "P12D");
+        Assert.assertEquals(adyenConfigProperties.getPendingHppPaymentWithouCompletionExpirationPeriod().toString(), "P12D");
     }
 
     @Test(groups = "fast")


### PR DESCRIPTION
Add a new property for HPP payments without completion actions.

For Hpp payments with completion action, it will use the PendingPaymentExpiry property. 

It also correct a bug that 3DS payment expiry policy was mistakenly used for Hpp pending as well (since both have a RedirectShopper result).