### PR TITLE
Use paymentProcessorAccountId to get the merchant account if it exists in the property

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The following properties are optional:
 * `org.killbill.billing.plugin.adyen.proxyPort`: Proxy server port
 * `org.killbill.billing.plugin.adyen.proxyType`: Proxy server type (HTTP or SOCKS)
 * `org.killbill.billing.plugin.adyen.trustAllCertificates`: Whether to disable SSL certificates validation
+* `org.killbill.billing.plugin.adyen.paymentProcessorAccountIdToMerchantAccount`: Mappings from the `paymentProcessorAccountId` to Adyen merchant accounts. The `paymentProcessorAccountId`, if exists in the plugin property, is a `String` set by the upstream logic to specify the merchant account used in the transaction.
 
 Only needed for the Tests:
 

--- a/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentPluginApi.java
@@ -110,6 +110,7 @@ public class AdyenPaymentPluginApi extends PluginPaymentPluginApi<AdyenResponses
 
     // Shared properties
     public static final String PROPERTY_PAYMENT_PROCESSOR_ACCOUNT_ID = "paymentProcessorAccountId";
+    public static final String PROPERTY_PAYMENT_PROCESSOR_MERCHANT_ACCOUNT_DESCRIPTOR = "paymentProcessorMerchantAccountDescriptor";
     public static final String PROPERTY_ACQUIRER = "acquirer";
     public static final String PROPERTY_ACQUIRER_MID = "acquirerMID";
     public static final String PROPERTY_SELECTED_BRAND = "selectedBrand";
@@ -992,6 +993,12 @@ public class AdyenPaymentPluginApi extends PluginPaymentPluginApi<AdyenResponses
     }
 
     private String getMerchantAccount(final String countryCode, @Nullable final AdyenResponsesRecord adyenResponsesRecord, final Iterable<PluginProperty> properties, final TenantContext context) {
+        final String pluginPropertyMerchantAccountDescriptor =
+                PluginProperties.findPluginPropertyValue(PROPERTY_PAYMENT_PROCESSOR_MERCHANT_ACCOUNT_DESCRIPTOR, properties);
+        if (pluginPropertyMerchantAccountDescriptor != null) {
+            return getConfigProperties(context).getMerchantAccountOfDescriptor(pluginPropertyMerchantAccountDescriptor);
+        }
+
         final String pluginPropertyMerchantAccount = PluginProperties.findPluginPropertyValue(PROPERTY_PAYMENT_PROCESSOR_ACCOUNT_ID, properties);
         if (pluginPropertyMerchantAccount != null) {
             return pluginPropertyMerchantAccount;

--- a/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentPluginApi.java
@@ -1001,10 +1001,7 @@ public class AdyenPaymentPluginApi extends PluginPaymentPluginApi<AdyenResponses
         return getMerchantAccount(countryCode, null, properties, context);
     }
 
-    private String getMerchantAccount(final String countryCode,
-                                      @Nullable final AdyenResponsesRecord adyenResponsesRecord,
-                                      final Iterable<PluginProperty> properties,
-                                      final TenantContext context) {
+    private String getMerchantAccount(final String countryCode, @Nullable final AdyenResponsesRecord adyenResponsesRecord, final Iterable<PluginProperty> properties, final TenantContext context) {
         final String paymentProcessorAccountId = PluginProperties.findPluginPropertyValue(PROPERTY_PAYMENT_PROCESSOR_ACCOUNT_ID, properties);
         if (paymentProcessorAccountId != null) {
             return getConfigProperties(context)

--- a/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentPluginApi.java
@@ -110,7 +110,6 @@ public class AdyenPaymentPluginApi extends PluginPaymentPluginApi<AdyenResponses
 
     // Shared properties
     public static final String PROPERTY_PAYMENT_PROCESSOR_ACCOUNT_ID = "paymentProcessorAccountId";
-    public static final String PROPERTY_PAYMENT_PROCESSOR_MERCHANT_ACCOUNT_DESCRIPTOR = "paymentProcessorMerchantAccountDescriptor";
     public static final String PROPERTY_ACQUIRER = "acquirer";
     public static final String PROPERTY_ACQUIRER_MID = "acquirerMID";
     public static final String PROPERTY_SELECTED_BRAND = "selectedBrand";
@@ -992,16 +991,19 @@ public class AdyenPaymentPluginApi extends PluginPaymentPluginApi<AdyenResponses
         return getMerchantAccount(countryCode, null, properties, context);
     }
 
-    private String getMerchantAccount(final String countryCode, @Nullable final AdyenResponsesRecord adyenResponsesRecord, final Iterable<PluginProperty> properties, final TenantContext context) {
-        final String pluginPropertyMerchantAccountDescriptor =
-                PluginProperties.findPluginPropertyValue(PROPERTY_PAYMENT_PROCESSOR_MERCHANT_ACCOUNT_DESCRIPTOR, properties);
-        if (pluginPropertyMerchantAccountDescriptor != null) {
-            return getConfigProperties(context).getMerchantAccountOfDescriptor(pluginPropertyMerchantAccountDescriptor);
-        }
-
-        final String pluginPropertyMerchantAccount = PluginProperties.findPluginPropertyValue(PROPERTY_PAYMENT_PROCESSOR_ACCOUNT_ID, properties);
-        if (pluginPropertyMerchantAccount != null) {
-            return pluginPropertyMerchantAccount;
+    private String getMerchantAccount(final String countryCode,
+                                      @Nullable final AdyenResponsesRecord adyenResponsesRecord,
+                                      final Iterable<PluginProperty> properties,
+                                      final TenantContext context) {
+        final String paymentProcessorAccountId =
+                PluginProperties.findPluginPropertyValue(PROPERTY_PAYMENT_PROCESSOR_ACCOUNT_ID, properties);
+        if (paymentProcessorAccountId != null) {
+            return getConfigProperties(context)
+                    .getMerchantAccountOfPaymentProcessorAccountId(paymentProcessorAccountId)
+                    .orElseGet(() -> {
+                        logger.info("Cannot find a mapping for '{}', fallback to use it directly", paymentProcessorAccountId);
+                        return paymentProcessorAccountId;
+                    });
         }
 
         if (adyenResponsesRecord != null) {

--- a/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/api/AdyenPaymentPluginApi.java
@@ -26,6 +26,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 import javax.xml.bind.JAXBException;
@@ -995,14 +996,16 @@ public class AdyenPaymentPluginApi extends PluginPaymentPluginApi<AdyenResponses
                                       @Nullable final AdyenResponsesRecord adyenResponsesRecord,
                                       final Iterable<PluginProperty> properties,
                                       final TenantContext context) {
-        final String paymentProcessorAccountId =
-                PluginProperties.findPluginPropertyValue(PROPERTY_PAYMENT_PROCESSOR_ACCOUNT_ID, properties);
+        final String paymentProcessorAccountId = PluginProperties.findPluginPropertyValue(PROPERTY_PAYMENT_PROCESSOR_ACCOUNT_ID, properties);
         if (paymentProcessorAccountId != null) {
             return getConfigProperties(context)
                     .getMerchantAccountOfPaymentProcessorAccountId(paymentProcessorAccountId)
-                    .orElseGet(() -> {
-                        logger.info("Cannot find a mapping for '{}', fallback to use it directly", paymentProcessorAccountId);
-                        return paymentProcessorAccountId;
+                    .orElseGet(new Supplier<String>() {
+                        @Override
+                        public String get() {
+                            logger.debug("Cannot find a mapping for '{}', fallback to use it directly", paymentProcessorAccountId);
+                            return paymentProcessorAccountId;
+                        }
                     });
         }
 

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/AdyenConfigProperties.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/AdyenConfigProperties.java
@@ -61,7 +61,7 @@ public class AdyenConfigProperties {
     private static final String DEFAULT_CONNECTION_TIMEOUT = "30000";
     private static final String DEFAULT_READ_TIMEOUT = "60000";
 
-    private final Map<String, String> descriptorToMerchantAccountMap = new LinkedHashMap<>();
+    private final Map<String, String> paymentProcessorAccountIdToMerchantAccountMap = new LinkedHashMap<>();
     private final Map<String, String> countryToMerchantAccountMap = new LinkedHashMap<String, String>();
     private final Map<String, String> merchantAccountToUsernameMap = new LinkedHashMap<String, String>();
     private final Map<String, String> usernameToPasswordMap = new LinkedHashMap<String, String>();
@@ -73,7 +73,7 @@ public class AdyenConfigProperties {
     private final Map<String, String> regionToRecurringUrlMap = new LinkedHashMap<String, String>();
     private final Map<String, String> regionToDirectoryUrlMap = new LinkedHashMap<String, String>();
 
-    private final String descriptorToMerchantAccount;
+    private final String paymentProcessorAccountIdToMerchantAccount;
     private final String merchantAccounts;
     private final String userNames;
     private final String passwords;
@@ -150,8 +150,8 @@ public class AdyenConfigProperties {
 
         this.acquirersList = properties.getProperty(PROPERTY_PREFIX + "acquirersList");
 
-        this.descriptorToMerchantAccount = properties.getProperty(PROPERTY_PREFIX + "descriptorToMerchantAccount");
-        refillMap(descriptorToMerchantAccountMap, descriptorToMerchantAccount);
+        this.paymentProcessorAccountIdToMerchantAccount = properties.getProperty(PROPERTY_PREFIX + "paymentProcessorAccountIdToMerchantAccount");
+        refillMap(paymentProcessorAccountIdToMerchantAccountMap, paymentProcessorAccountIdToMerchantAccount);
 
         this.merchantAccounts = properties.getProperty(PROPERTY_PREFIX + "merchantAccount");
         refillMap(countryToMerchantAccountMap, merchantAccounts);
@@ -280,9 +280,8 @@ public class AdyenConfigProperties {
         return chargebackAsFailurePaymentMethods;
     }
 
-    public String getMerchantAccountOfDescriptor(final String descriptor) {
-        return Optional.ofNullable(descriptorToMerchantAccountMap.get(descriptor))
-                       .orElseThrow(() -> new IllegalStateException(String.format("Failed to find merchant account for descriptor='%s'", descriptor)));
+    public Optional<String> getMerchantAccountOfPaymentProcessorAccountId(final String paymentProcessorAccountId) {
+        return Optional.ofNullable(paymentProcessorAccountIdToMerchantAccountMap.get(paymentProcessorAccountId));
     }
 
     public String getMerchantAccount(final String countryIsoCode) {

--- a/src/main/java/org/killbill/billing/plugin/adyen/client/AdyenConfigProperties.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/AdyenConfigProperties.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
@@ -60,6 +61,7 @@ public class AdyenConfigProperties {
     private static final String DEFAULT_CONNECTION_TIMEOUT = "30000";
     private static final String DEFAULT_READ_TIMEOUT = "60000";
 
+    private final Map<String, String> descriptorToMerchantAccountMap = new LinkedHashMap<>();
     private final Map<String, String> countryToMerchantAccountMap = new LinkedHashMap<String, String>();
     private final Map<String, String> merchantAccountToUsernameMap = new LinkedHashMap<String, String>();
     private final Map<String, String> usernameToPasswordMap = new LinkedHashMap<String, String>();
@@ -71,6 +73,7 @@ public class AdyenConfigProperties {
     private final Map<String, String> regionToRecurringUrlMap = new LinkedHashMap<String, String>();
     private final Map<String, String> regionToDirectoryUrlMap = new LinkedHashMap<String, String>();
 
+    private final String descriptorToMerchantAccount;
     private final String merchantAccounts;
     private final String userNames;
     private final String passwords;
@@ -146,6 +149,9 @@ public class AdyenConfigProperties {
         this.pendingHppPaymentWithoutCompletionExpirationPeriod = readPendingHppPaymentWithoutCompletionExpirationPeriod(properties);
 
         this.acquirersList = properties.getProperty(PROPERTY_PREFIX + "acquirersList");
+
+        this.descriptorToMerchantAccount = properties.getProperty(PROPERTY_PREFIX + "descriptorToMerchantAccount");
+        refillMap(descriptorToMerchantAccountMap, descriptorToMerchantAccount);
 
         this.merchantAccounts = properties.getProperty(PROPERTY_PREFIX + "merchantAccount");
         refillMap(countryToMerchantAccountMap, merchantAccounts);
@@ -272,6 +278,11 @@ public class AdyenConfigProperties {
 
     public Set<String> getChargebackAsFailurePaymentMethods() {
         return chargebackAsFailurePaymentMethods;
+    }
+
+    public String getMerchantAccountOfDescriptor(final String descriptor) {
+        return Optional.ofNullable(descriptorToMerchantAccountMap.get(descriptor))
+                       .orElseThrow(() -> new IllegalStateException(String.format("Failed to find merchant account for descriptor='%s'", descriptor)));
     }
 
     public String getMerchantAccount(final String countryIsoCode) {


### PR DESCRIPTION
Support mapping the `paymentProcessorAccountId` of the plugin properties to actual Adyen merchant account.

If no mapping found, it fails back to using the string directly.