### PR TITLE
Allow passwords (and other config entries) to contain '#' char…

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/adyen/client/AdyenConfigProperties.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/AdyenConfigProperties.java
@@ -468,7 +468,7 @@ public class AdyenConfigProperties {
         map.clear();
         if (!Strings.isNullOrEmpty(stringToSplit)) {
             for (final String entry : stringToSplit.split("\\" + ENTRY_DELIMITER)) {
-                final String[] split = entry.split(KEY_VALUE_DELIMITER);
+                final String[] split = entry.split(KEY_VALUE_DELIMITER, 2);
                 if (split.length > 1) {
                     map.put(split[0], split[1]);
                 }

--- a/src/test/java/org/killbill/billing/plugin/adyen/client/TestAdyenConfigProperties.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/client/TestAdyenConfigProperties.java
@@ -74,7 +74,7 @@ public class TestAdyenConfigProperties {
         final Properties properties = new Properties();
         properties.put("org.killbill.billing.plugin.adyen.merchantAccount", "UK#DefaultAccountUK|DE#DefaultAccountDE|US#DefaultAccountUS");
         properties.put("org.killbill.billing.plugin.adyen.username", "UK#DefaultUsernameUK|DE#DefaultUsernameDE|US#DefaultUsernameUS");
-        properties.put("org.killbill.billing.plugin.adyen.password", "UK#DefaultPasswordUK|DE#DefaultPasswordDE|DefaultUsernameUS#DefaultPasswordUS");
+        properties.put("org.killbill.billing.plugin.adyen.password", "UK#DefaultPasswordUK|DE#DefaultPasswordDE|DefaultUsernameUS#Default#PasswordUS");
         properties.put("org.killbill.billing.plugin.adyen.skin", "UK#DefaultSkinUK|US#DefaultSkinUS|DE#DefaultSkinDE");
         properties.put("org.killbill.billing.plugin.adyen.hmac.secret", "UK#DefaultSecretUK|US#DefaultSecretUS|DE#DefaultSecretDE");
         properties.put("org.killbill.billing.plugin.adyen.hmac.algorithm", "UK#DefaultAlgorithmUK|US#DefaultAlgorithmUS|DE#DefaultAlgorithmDE");
@@ -91,7 +91,7 @@ public class TestAdyenConfigProperties {
 
         Assert.assertEquals(adyenConfigProperties.getPassword("DefaultUsernameUK"), "DefaultPasswordUK");
         Assert.assertEquals(adyenConfigProperties.getPassword("DefaultUsernameDE"), "DefaultPasswordDE");
-        Assert.assertEquals(adyenConfigProperties.getPassword("DefaultUsernameUS"), "DefaultPasswordUS");
+        Assert.assertEquals(adyenConfigProperties.getPassword("DefaultUsernameUS"), "Default#PasswordUS");
 
         Assert.assertEquals(adyenConfigProperties.getSkin("DefaultAccountUK"), "DefaultSkinUK");
         Assert.assertEquals(adyenConfigProperties.getSkin("DefaultAccountDE"), "DefaultSkinDE");
@@ -118,9 +118,9 @@ public class TestAdyenConfigProperties {
         final Properties properties = new Properties();
         properties.put("org.killbill.billing.plugin.adyen.merchantAccount", "UK#DefaultAccountUK|DE#DefaultAccountDE|US#DefaultAccountUS");
         properties.put("org.killbill.billing.plugin.adyen.username", "UK#DefaultUsernameUK|DE#DefaultUsernameDE|OverrideAccountUK#OverrideUsernameUK|US#DefaultUsernameUS");
-        properties.put("org.killbill.billing.plugin.adyen.password", "UK#DefaultPasswordUK|OverrideUsernameUK#OverridePasswordUK|DE#DefaultPasswordDE|DefaultUsernameUS#DefaultPasswordUS");
+        properties.put("org.killbill.billing.plugin.adyen.password", "UK#DefaultPasswordUK|OverrideUsernameUK#OverridePasswordUK|DE#DefaultPasswordDE|DefaultUsernameUS#Default#PasswordUS");
         properties.put("org.killbill.billing.plugin.adyen.skin", "UK#DefaultSkinUK|OverrideAccountUK#OverrideSkinUK|US#DefaultSkinUS|DE#DefaultSkinDE");
-        properties.put("org.killbill.billing.plugin.adyen.hmac.secret", "UK#DefaultSecretUK|OverrideSkinUK#OverrideSecretUK|US#DefaultSecretUS|DE#DefaultSecretDE");
+        properties.put("org.killbill.billing.plugin.adyen.hmac.secret", "UK#DefaultSecretUK|OverrideSkinUK#OverrideSecretUK|US#Default#SecretUS|DE#DefaultSecretDE");
         properties.put("org.killbill.billing.plugin.adyen.hmac.algorithm", "UK#DefaultAlgorithmUK|OverrideSkinUK#OverrideAlgorithmUK|US#DefaultAlgorithmUS|DE#DefaultAlgorithmDE");
         properties.put("org.killbill.billing.plugin.adyen.pendingPaymentExpirationPeriod", "paypal#P4D|boletobancario_santander#P12D");
         properties.put("org.killbill.billing.plugin.adyen.pendingHppPaymentWithoutCompletionExpirationPeriod", "P12D");
@@ -138,7 +138,7 @@ public class TestAdyenConfigProperties {
         Assert.assertEquals(adyenConfigProperties.getPassword("DefaultUsernameUK"), "DefaultPasswordUK");
         Assert.assertEquals(adyenConfigProperties.getPassword("OverrideUsernameUK"), "OverridePasswordUK");
         Assert.assertEquals(adyenConfigProperties.getPassword("DefaultUsernameDE"), "DefaultPasswordDE");
-        Assert.assertEquals(adyenConfigProperties.getPassword("DefaultUsernameUS"), "DefaultPasswordUS");
+        Assert.assertEquals(adyenConfigProperties.getPassword("DefaultUsernameUS"), "Default#PasswordUS");
 
         Assert.assertEquals(adyenConfigProperties.getSkin("DefaultAccountUK"), "DefaultSkinUK");
         Assert.assertEquals(adyenConfigProperties.getSkin("OverrideAccountUK"), "OverrideSkinUK");
@@ -148,7 +148,7 @@ public class TestAdyenConfigProperties {
         Assert.assertEquals(adyenConfigProperties.getHmacSecret("DefaultSkinUK"), "DefaultSecretUK");
         Assert.assertEquals(adyenConfigProperties.getHmacSecret("OverrideSkinUK"), "OverrideSecretUK");
         Assert.assertEquals(adyenConfigProperties.getHmacSecret("DefaultSkinDE"), "DefaultSecretDE");
-        Assert.assertEquals(adyenConfigProperties.getHmacSecret("DefaultSkinUS"), "DefaultSecretUS");
+        Assert.assertEquals(adyenConfigProperties.getHmacSecret("DefaultSkinUS"), "Default#SecretUS");
 
         Assert.assertEquals(adyenConfigProperties.getHmacAlgorithm("DefaultSkinUK"), "DefaultAlgorithmUK");
         Assert.assertEquals(adyenConfigProperties.getHmacAlgorithm("OverrideSkinUK"), "OverrideAlgorithmUK");


### PR DESCRIPTION
…acter

The plugin expects credential configuration entries in the format
`username#password` (each separated by '|'). This breaks authentication
if username or password contain the character '#'.

While this could be considered uncommon for a username, it could easily
happen for a password, considering that Adyen Customer Area provides
only automatically generated ones.

This commits introduces a simple workaround to mitigate the issue.